### PR TITLE
[EINT-4] Use OS settings for `light/dark` mode

### DIFF
--- a/RoktDemo/UI/Home/HomePageView.swift
+++ b/RoktDemo/UI/Home/HomePageView.swift
@@ -78,11 +78,15 @@ struct HomePageView: View {
                         .font(.defaultFont(.subtitle2))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.textColor)
+                        .padding(.bottom)
                 }.padding()
-            }.background(Color.white)
-        }.background(Color.white).navigationViewStyle(StackNavigationViewStyle())
+            }
+            .background(Color.white)
+            .edgesIgnoringSafeArea(.all)
+        }
+        .background(Color.white)
+        .navigationViewStyle(StackNavigationViewStyle())
         .modifier(NavigationBarTransparent(title: ""))
-        .preferredColorScheme(.light)
     }
 }
 


### PR DESCRIPTION
### Background ###

Previously, the app enforced the use of light mode, irrespective of the System settings. 
The effect is most visible in embedded placements. In dark mode, when an embedded offer is shown, the icon should be hidden. Prior to the fix, this was not happening.

Fixes [https://rokt.atlassian.net/browse/EINT-4]

### What Has Changed: ###
1. Remove forced light mode
2. Ensure entire screen is covered in Home

### How Has This Been Tested? ###
- run the app in light mode. check embedded placements. should SHOW icons
https://user-images.githubusercontent.com/118139797/202327043-3c2d4d64-9410-41fa-8a2e-127f79e497e7.mp4

- run the app in dark mode. check embedded placements. should HIDE icons
https://user-images.githubusercontent.com/118139797/202327049-e6591bea-7c8f-4f01-9979-130b1833dd51.mp4

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.