### PR TITLE
bump sdk dependency to 3.12.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ target 'RoktDemo' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
   # Pods for RoktDemo
-  pod 'Rokt-Widget', '~> 3.11.0'
+  pod 'Rokt-Widget', '~> 3.12.0'
   pod 'Alamofire', '~> 5.4.4'
   pod 'SDWebImageSwiftUI', '~> 2.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (5.4.4)
-  - Rokt-Widget (3.11.0)
+  - Rokt-Widget (3.12.0)
   - SDWebImage (5.13.4):
     - SDWebImage/Core (= 5.13.4)
   - SDWebImage/Core (5.13.4)
@@ -9,7 +9,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 5.4.4)
-  - Rokt-Widget (~> 3.11.0)
+  - Rokt-Widget (~> 3.12.0)
   - SDWebImageSwiftUI (~> 2.0.2)
 
 SPEC REPOS:
@@ -21,10 +21,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
-  Rokt-Widget: f02a9fe2f5e3c186aace3a531b62daab4d54f0ab
+  Rokt-Widget: 34851c3d484c848edaee2d56068a6f9452b9f941
   SDWebImage: e5cc87bf736e60f49592f307bdf9e157189298a3
   SDWebImageSwiftUI: 8a3923c95108312b03a599ec1498754af55a6819
 
-PODFILE CHECKSUM: dcf34d065e7a926f3d83b90b236bf3badab908cb
+PODFILE CHECKSUM: 84d118e65dc0cddc4e0fe73f98643dc8c07036b6
 
 COCOAPODS: 1.12.0

--- a/RoktDemo.xcodeproj/project.pbxproj
+++ b/RoktDemo.xcodeproj/project.pbxproj
@@ -1225,7 +1225,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "\"RoktDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = EX8W57PJ9C;
 				ENABLE_PREVIEWS = YES;
@@ -1235,7 +1235,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.0;
+				MARKETING_VERSION = 3.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rokt.RoktDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.rokt.RoktDemo";
@@ -1252,7 +1252,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "\"RoktDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = EX8W57PJ9C;
 				ENABLE_PREVIEWS = YES;
@@ -1262,7 +1262,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.0;
+				MARKETING_VERSION = 3.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rokt.RoktDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.rokt.RoktDemo";


### PR DESCRIPTION
### Background ###

Upgrading to version 3.12.0.

### What Has Changed: ###

Change SDK dependency in podfile to 3.12.0.

### How Has This Been Tested? ###

Run demo app.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.