### PR TITLE
[MP-1899] Buildkite Pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
       - rbenv local 2.7.6
       - bundle install --path vendor/bundle
       - xcrun simctl boot "iPhone 14" || true
-      - pod install --verbose
+      - pod install --verbose --repo-update
       - bundle exec fastlane test
       - xcrun simctl shutdown "iPhone 14" || true
     agents:      
@@ -27,7 +27,7 @@ steps:
       - rbenv local 2.7.6
       - bundle install --path vendor/bundle
       - xcrun simctl boot "iPhone 14" || true
-      - pod install --verbose
+      - pod install --verbose --repo-update
       - bundle exec fastlane beta refresh_certificates:false use_temporary_keychain:true
       - xcrun simctl shutdown "iPhone 14" || true
     depends_on: 'publish-block'
@@ -70,7 +70,7 @@ steps:
       - . ~/.zshrc
       - bundle install --path vendor/bundle
       - xcrun simctl boot "iPhone 14" || true
-      - pod install --verbose
+      - pod install --verbose --repo-update
       - bundle exec fastlane beta refresh_certificates:false use_temporary_keychain:true
       - xcrun simctl shutdown "iPhone 14" || true
     depends_on: "unit-test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,110 @@
+env:
+  MAC_BK_AGENT: eng-prod-us-west-2-mac-arm-macos-build-medium
+
+steps:
+  - name: ':hammer: Build and Unit Test iOS Demo'
+    key: 'unit-test'
+    commands:
+      - . ~/.zshrc
+      - rbenv local 2.7.6
+      - bundle install --path vendor/bundle
+      - xcrun simctl boot "iPhone 14" || true
+      - pod install --verbose
+      - bundle exec fastlane test
+      - xcrun simctl shutdown "iPhone 14" || true
+    agents:      
+      queue: ${MAC_BK_AGENT}
+    timeout_in_minutes: 25
+
+  - block: ':whale: Publish to TestFlight'
+    key: 'publish-block'
+    prompt: 'Confirm publishing to TestFlight?'
+    depends_on: 'unit-test'
+
+  - name: ':rocket: Publish demo app to TestFlight'
+    commands:
+      - . ~/.zshrc
+      - rbenv local 2.7.6
+      - bundle install --path vendor/bundle
+      - xcrun simctl boot "iPhone 14" || true
+      - pod install --verbose
+      - bundle exec fastlane beta refresh_certificates:false use_temporary_keychain:true
+      - xcrun simctl shutdown "iPhone 14" || true
+    depends_on: 'publish-block'
+    plugins:
+      - seek-oss/aws-sm#v2.0.0:
+          env:
+            APPSTORE_KEY_ID:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.APPSTORE_KEY_ID'
+            APPSTORE_ISSUER_ID:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.APPSTORE_ISSUER_ID'
+            APPSTORE_KEY_CONTENT_B64:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.APPSTORE_KEY_CONTENT_B64'
+            MATCH_GIT_URL:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_GIT_URL'
+            MATCH_GIT_BRANCH:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_GIT_BRANCH'
+            MATCH_USERNAME:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_USERNAME'
+            MATCH_GIT_USER_EMAIL:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_GIT_USER_EMAIL'
+            MATCH_PASSWORD:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_PASSWORD'
+            DEVELOPMENT_TEAM_ID:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.DEVELOPMENT_TEAM_ID'
+    agents:      
+      queue: ${MAC_BK_AGENT}
+    timeout_in_minutes: 25
+
+  - name: ':alarm_clock::rocket: [Scheduled] Publish demo app to TestFlight'
+    commands:
+      - . ~/.zshrc
+      - bundle install --path vendor/bundle
+      - xcrun simctl boot "iPhone 14" || true
+      - pod install --verbose
+      - bundle exec fastlane beta refresh_certificates:false use_temporary_keychain:true
+      - xcrun simctl shutdown "iPhone 14" || true
+    depends_on: "unit-test"
+    if: build.source == "schedule"
+    plugins:
+      - seek-oss/aws-sm#v2.0.0:
+          env:
+            APPSTORE_KEY_ID:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.APPSTORE_KEY_ID'
+            APPSTORE_ISSUER_ID:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.APPSTORE_ISSUER_ID'
+            APPSTORE_KEY_CONTENT_B64:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.APPSTORE_KEY_CONTENT_B64'
+            MATCH_GIT_URL:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_GIT_URL'
+            MATCH_GIT_BRANCH:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_GIT_BRANCH'
+            MATCH_USERNAME:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_USERNAME'
+            MATCH_GIT_USER_EMAIL:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_GIT_USER_EMAIL'
+            MATCH_PASSWORD:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.MATCH_PASSWORD'
+            DEVELOPMENT_TEAM_ID:
+              secret-id: 'stage-ios-demoapp-buildkite'
+              json-key: '.DEVELOPMENT_TEAM_ID'
+    agents:      
+      queue: ${MAC_BK_AGENT}
+    timeout_in_minutes: 25

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Pods/
+commit.sh
+git-commit-template.txt

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "cocoapods"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This app distributed internally via [TestFlight](https://developer.apple.com/tes
 | Environment | Build |
 | ----------- | :----- |
 | release |  [![CircleCI](https://dl.circleci.com/status-badge/img/gh/ROKT/rokt-demo-ios/tree/release-1.1.x.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ROKT/rokt-demo-ios/tree/release-1.1.x)
+| release | [![Build status](https://badge.buildkite.com/afe921fff6fe587a6a59245ca0181c61d5557c78893991f9cc.svg)](https://buildkite.com/rokt/rokt-demo-ios?branch=release-1.1.x)
 ### Developer Note
-Modify the Circleci url whenever default branch is changed.
+Modify the Circleci and Buildkite url whenever default branch is changed.
 
 
 ## Requirements

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,15 +15,21 @@
 
 default_platform(:ios)
 
+BUILD_NUMBER =  if !ENV["CIRCLE_BUILD_NUMBER"].nil?
+                  ENV["CIRCLE_BUILD_NUMBER"]
+                else 
+                  ENV["BUILDKITE_BUILD_NUMBER"]
+                end
+
 platform :ios do
-  before_all do
-    setup_circle_ci
-  end
+  # before_all do
+  #   setup_circle_ci
+  # end
 
   desc "Runs all the tests"
   lane :test do
     scan(
-      devices: ["iPhone 12"]
+      devices: ["iPhone 14"]
       )
   end
 
@@ -88,7 +94,7 @@ platform :ios do
     )
 
     increment_build_number(
-        build_number: ENV["CIRCLE_BUILD_NUM"]
+        build_number: BUILD_NUMBER
     )
 
     settings_to_override = {


### PR DESCRIPTION
### Background ###

This PR adds a buildkite pipeline to the iOS demo app that will eventually replace the current CircleCI pipeline.

Fixes [MP-1866](https://rokt.atlassian.net/browse/MP-1899?atlOrigin=eyJpIjoiNTVjODNiZjlhNTMyNDI0NWFiNjM5MzJmNTQyODBjNjEiLCJwIjoiaiJ9)

### What Has Changed: ###

- Implemented buildkite pipeline
- Added a schedule to automatically publish the app to testflight every month
- Buildkite pipeline is over 2x as fast as CircleCI

### How Has This Been Tested? ###

Verified the pipeline stages.

![image](https://user-images.githubusercontent.com/122851605/231045637-62f0bbe0-c364-4582-8ee5-2956845fe5fb.png)

### Notes

Pipeline: https://buildkite.com/rokt/rokt-demo-ios
CircleCI pipeline still functions normally.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.