### PR TITLE
support dark mode on layout preview

### DIFF
--- a/RoktDemo/UI/Placement Demo/Error/ErrorView.swift
+++ b/RoktDemo/UI/Placement Demo/Error/ErrorView.swift
@@ -28,16 +28,21 @@ struct ErrorView: View {
                 case .network:
                     Text("No network connection. Please try again later once connected.")
                         .font(.defaultHeadingFont(.header1))
+                        .foregroundColor(.black)
                 case .barcode:
                     Text("Invalid QR code data.")
                         .font(.defaultHeadingFont(.header1))
+                        .foregroundColor(.black)
                     Text("Please scan the correct QR code from the One Platform layouts preview page. If the issue persists please contact us at www.rokt.com or try again later.")
                         .font(.defaultFont(.text))
                         .padding(.top)
+                        .foregroundColor(.black)
                 case .general:
                     Text("Our systems aren't responding right now.")
                         .font(.defaultHeadingFont(.header1))
+                        .foregroundColor(.black)
                     Text("Please close the app and try again. If the issue persists please contact us at www.rokt.com or try again later.")
+                        .foregroundColor(.black)
                         .font(.defaultFont(.text))
                         .padding(.top)
                 }


### PR DESCRIPTION
### Background ###

Supporting Darkmode on Layout preview page.

### How Has This Been Tested? ###

Before:
![IMG_82DB54C36D7F-1](https://github.com/ROKT/rokt-demo-ios/assets/49017604/cb6e7a7a-8445-42b1-9f0e-7063b3f360e2)

After:
![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 08 50 22](https://github.com/ROKT/rokt-demo-ios/assets/49017604/2e1d52a7-07c9-48c3-b28c-0a6b7e093c28)


### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.