### PR TITLE
LAYOUT-1041: Support demoConfig and rokt.language in preview

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ target 'RoktDemo' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
   # Pods for RoktDemo
-  pod 'Rokt-Widget', '4.3.0'
+  pod 'Rokt-Widget', '4.5.0'
   pod 'Alamofire', '~> 5.4.4'
   pod 'SDWebImageSwiftUI', '~> 2.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (5.4.4)
-  - Rokt-Widget (4.2.1-alpha.2)
+  - Rokt-Widget (4.5.0)
   - SDWebImage (5.15.5):
     - SDWebImage/Core (= 5.15.5)
   - SDWebImage/Core (5.15.5)
@@ -9,7 +9,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 5.4.4)
-  - Rokt-Widget (= 4.2.1-alpha.2)
+  - Rokt-Widget (= 4.5.0)
   - SDWebImageSwiftUI (~> 2.0.2)
 
 SPEC REPOS:
@@ -21,10 +21,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
-  Rokt-Widget: 6680074bcea4f1b703e74825e251254399d645aa
+  Rokt-Widget: f4305cd119341cdbc18d58d3827fcbd6472d51d6
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
   SDWebImageSwiftUI: 8a3923c95108312b03a599ec1498754af55a6819
 
-PODFILE CHECKSUM: 7a100f783dfd05ceb4c838f38209909964643a69
+PODFILE CHECKSUM: bc080232a149084dc6dd432f31bf382ee7022ff0
 
 COCOAPODS: 1.15.2

--- a/RoktDemo.xcodeproj/project.pbxproj
+++ b/RoktDemo.xcodeproj/project.pbxproj
@@ -1291,7 +1291,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.2.1;
+				MARKETING_VERSION = 4.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rokt.RoktDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.rokt.RoktDemo";
@@ -1318,7 +1318,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.2.1;
+				MARKETING_VERSION = 4.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rokt.RoktDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.rokt.RoktDemo";

--- a/RoktDemo/Model/Layouts/PreviewData.swift
+++ b/RoktDemo/Model/Layouts/PreviewData.swift
@@ -17,5 +17,14 @@ struct PreviewData: Decodable {
     let tagId: String
     let previewId: String
     let versionId: String
-    let creativeIds: [String]
+    let roktLanguage: String
+    let demoConfig: String
+
+    enum CodingKeys: String, CodingKey {
+        case tagId
+        case previewId
+        case versionId
+        case roktLanguage = "rokt.language"
+        case demoConfig
+    }
 }

--- a/RoktDemo/Model/Layouts/PreviewData.swift
+++ b/RoktDemo/Model/Layouts/PreviewData.swift
@@ -17,14 +17,7 @@ struct PreviewData: Decodable {
     let tagId: String
     let previewId: String
     let versionId: String
-    let roktLanguage: String
-    let demoConfig: String
-
-    enum CodingKeys: String, CodingKey {
-        case tagId
-        case previewId
-        case versionId
-        case roktLanguage = "rokt.language"
-        case demoConfig
-    }
+    let creativeIds: [String]
+    let layoutVariantIds: [String]
+    let language: String
 }

--- a/RoktDemo/UI/Layout Demo/LayoutDemoView.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoView.swift
@@ -47,18 +47,18 @@ struct LayoutDemoView: View {
                         }
                         
                         switch viewModel.uiState {
-                        // TODO: Re-enable the refresh button once layoutVariantIds are stablised
-                        // case .hasData, .done:
-                        //     Button(action: {
-                        //         viewModel.uiState = .hasData
-                        //     }) {
-                        //         Text("Refresh preview")
-                        //     }
-                        //     .padding(.top)
-                        //     .buttonStyle(ButtonDefaultOutlined())
+                        case .hasData, .done:
+                            // TODO: Re-enable the refresh button once layoutVariantIds are stablised
+                            //     Button(action: {
+                            //         viewModel.uiState = .hasData
+                            //     }) {
+                            //         Text("Refresh preview")
+                            //     }
+                            //     .padding(.top)
+                            //     .buttonStyle(ButtonDefaultOutlined())
                             
-                        //     roktEmbedded
-                        //         .frame(height: self.embeddedSize, alignment: .center)
+                            roktEmbedded
+                                .frame(height: self.embeddedSize, alignment: .center)
                             
                         case .error(error: let error):
                             ErrorView(viewModel: ErrorViewModel(error: nil, barcodeErrorMessage: error))

--- a/RoktDemo/UI/Layout Demo/LayoutDemoView.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoView.swift
@@ -47,17 +47,18 @@ struct LayoutDemoView: View {
                         }
                         
                         switch viewModel.uiState {
-                        case .hasData, .done:
-                            Button(action: {
-                                viewModel.uiState = .hasData
-                            }) {
-                                Text("Refresh preview")
-                            }
-                            .padding(.top)
-                            .buttonStyle(ButtonDefaultOutlined())
+                        // TODO: Re-enable the refresh button once layoutVariantIds are stablised
+                        // case .hasData, .done:
+                        //     Button(action: {
+                        //         viewModel.uiState = .hasData
+                        //     }) {
+                        //         Text("Refresh preview")
+                        //     }
+                        //     .padding(.top)
+                        //     .buttonStyle(ButtonDefaultOutlined())
                             
-                            roktEmbedded
-                                .frame(height: self.embeddedSize, alignment: .center)
+                        //     roktEmbedded
+                        //         .frame(height: self.embeddedSize, alignment: .center)
                             
                         case .error(error: let error):
                             ErrorView(viewModel: ErrorViewModel(error: nil, barcodeErrorMessage: error))

--- a/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
@@ -54,7 +54,8 @@ class LayoutDemoViewModel: ObservableObject {
         attributes["isDemo"] = "true"
         attributes["layoutId"] = preview.previewId
         attributes["versionId"] = preview.versionId
-        attributes["creativeId"] = preview.creativeIds.joined(separator: ",")
+        attributes["rokt.language"] = preview.roktLanguage
+        attributes["demoConfig"] = preview.demoConfig
         return attributes
     }
 }

--- a/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
@@ -52,10 +52,32 @@ class LayoutDemoViewModel: ObservableObject {
         guard let preview else { return [:] }
         var attributes = [String: String]()
         attributes["isDemo"] = "true"
-        attributes["layoutId"] = preview.previewId
-        attributes["versionId"] = preview.versionId
-        attributes["rokt.language"] = preview.roktLanguage
-        attributes["demoConfig"] = preview.demoConfig
+        attributes["rokt.language"] = preview.language
+        
+        var slots: [[String: String]] = [];
+        for (creativeId, layoutVariantId) in zip(preview.creativeIds, preview.layoutVariantIds) {
+            let slot: [String: String] = [
+                "layoutVariantId": layoutVariantId,
+                "creativeId": creativeId
+            ]
+            slots.append(slot)
+        }
+        
+        let demoConfig = [
+            "layouts": [
+                [
+                    "layoutId": preview.previewId,
+                    "versionId": preview.versionId,
+                    "slots": slots
+                ]
+            ]
+        ]
+        
+        if let demoConfigJson = try? JSONSerialization.data(withJSONObject: demoConfig, options: []),
+           let demoConfigJsonString = String(data: demoConfigJson, encoding: .utf8) {
+            attributes["demoConfig"] = demoConfigJsonString
+        }
+        
         return attributes
     }
 }

--- a/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
@@ -54,8 +54,11 @@ class LayoutDemoViewModel: ObservableObject {
         attributes["isDemo"] = "true"
         attributes["rokt.language"] = preview.language
         
-        var slots: [[String: String]] = [];
-        for (creativeId, layoutVariantId) in zip(preview.creativeIds, preview.layoutVariantIds) {
+        var slots: [[String: String]] = []
+        let layoutVariantCount = preview.layoutVariantIds.count
+        
+        for (index, creativeId) in preview.creativeIds.enumerated() {
+            let layoutVariantId = preview.layoutVariantIds[index % layoutVariantCount]
             let slot: [String: String] = [
                 "layoutVariantId": layoutVariantId,
                 "creativeId": creativeId


### PR DESCRIPTION
### Background ###

In order to support multiple layout variants and multi-language preview, we will need to support demoConfig and rokt.language in attributes

Fixes [LAYOUT-1041](https://rokt.atlassian.net/browse/LAYOUT-1041)

### What Has Changed: ###

- updated PreviewData to support demoConfig and rokt.language which are always sending
- removed creativeIds array which is not not needed as creativeIds are in demoConfig
- added demoConfig and rokt.language to getAttributes

### How Has This Been Tested? ###
example QR code content:
```
{
    "tagId": "3157272025983146467",
    "previewId": "3339067146982785095",
    "versionId": "1724121953217",
    "language": "en",
    "creativeIds": ["3297172498411225129", "3297172884958281775", "3297172786173902936", "3297173061051940916"],
    "layoutVariantIds": ["3339067275831803979", "3339067275831803980"],
  }
```
Can accept any number of layoutVariantIds (1 at least), loop through creativeIds, use layoutVariantIds one by one

example experiences call body
```
{
  "attributes": {
    "rokt.language": "en",
    "colormode": "LIGHT",
    "isDemo": "true",
    "demoConfig": "{\"layouts\":[{\"slots\":[{\"creativeId\":\"3297172498411225129\",\"layoutVariantId\":\"3339067275831803979\"},{\"layoutVariantId\":\"3339067275831803980\",\"creativeId\":\"3297172884958281775\"},{\"creativeId\":\"3297172786173902936\",\"layoutVariantId\":\"3339067275831803979\"},{\"creativeId\":\"3297173061051940916\",\"layoutVariantId\":\"3339067275831803980\"}],\"versionId\":\"1724121953217\",\"layoutId\":\"3339067146982785095\"}]}"
  },
  "pageIdentifier": ""
}
```

local test
BottomSheet
<img width="447" alt="image" src="https://github.com/user-attachments/assets/f9ce1d4b-22c1-4aa2-b7e2-aaff6b783b18">

Embedded
<img width="382" alt="image" src="https://github.com/user-attachments/assets/3b471088-2376-4fc0-8092-90b5b3b09cae">


Overlay
<img width="455" alt="image" src="https://github.com/user-attachments/assets/99e9ef66-0d0b-4881-a6ee-8a9ce59f0be4">

network is sending the correct request
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/1fe6b9c7-dd42-4511-ace2-e17604828788">

### Notes

Detected a bug in API side while testing, they will always get the first layoutVariant for now, should be fixed in https://rokt.atlassian.net/browse/PED-507

Demo app update is to be released later this sprint after communication with Ops

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.