### PR TITLE
fix: preserve multiline release notes in releases

### DIFF
--- a/.github/actions/upload-ipa/action.yml
+++ b/.github/actions/upload-ipa/action.yml
@@ -43,7 +43,12 @@ runs:
       shell: bash
       run: |
         if [ -n "${{ inputs.release_notes }}" ]; then
-          echo "release_text=${{ inputs.release_notes }}" >> $GITHUB_OUTPUT
+          RELEASE_NOTES_DELIMITER="RELEASE_NOTES_$(uuidgen)"
+          {
+            echo "release_text<<$RELEASE_NOTES_DELIMITER"
+            printf '%s\n' "${{ inputs.release_notes }}"
+            echo "$RELEASE_NOTES_DELIMITER"
+          } >> "$GITHUB_OUTPUT"
         fi
 
     - name: Upload IPA

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -57,10 +57,12 @@ jobs:
         id: release-notes
         run: |
           # Get the commit message of the last merge
-          RELEASE_NOTES=$(git log -1 --pretty=%B)
-          # Escape newlines and quotes for JSON
-          RELEASE_NOTES=$(echo "$RELEASE_NOTES" | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
-          echo "release_notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          RELEASE_NOTES_DELIMITER="RELEASE_NOTES_$(uuidgen)"
+          {
+            echo "release_notes<<$RELEASE_NOTES_DELIMITER"
+            git log -1 --pretty=%B
+            echo "$RELEASE_NOTES_DELIMITER"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload IPA to Firebase
         uses: ./.github/actions/upload-ipa


### PR DESCRIPTION
## Background

- The release workflow on `main` was failing when it tried to export the latest merge commit message as release notes.
- The step used a GNU-style `sed` multiline escape pattern on a macOS runner and then wrote a multiline value to `$GITHUB_OUTPUT` as a single-line output, which broke the workflow before Firebase upload and GitHub release creation.

## What Has Changed

- Replaced the `sed`-based release notes escaping in `release-from-main.yml` with GitHub Actions multiline output syntax.
- Added a unique delimiter via `uuidgen` so merge commit bodies with bullets, quotes, or blank lines are written safely to `$GITHUB_OUTPUT`.
- Kept the downstream workflow contract unchanged so the Firebase upload and GitHub release steps continue to consume `steps.release-notes.outputs.release_notes`.

## Screenshots/Video

- N/A — no visual changes

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Validated the output format locally with a multiline sample release note payload and reran the existing iOS test suite successfully.