### PR TITLE
fix: harden GitHub Actions workflows and add zizmor CI check

### DIFF
--- a/.github/workflows/distribute-to-firebase.yml
+++ b/.github/workflows/distribute-to-firebase.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       
       - name: Build IPA
         uses: ./.github/actions/build-ipa
@@ -28,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download IPA artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build IPA
         uses: ./.github/actions/build-ipa
@@ -36,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download IPA artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install zizmor
+        run: pipx install zizmor==1.23.1
+      # continue-on-error: true until pre-existing findings are resolved.
+      # Once triaged, remove this flag to make zizmor a hard blocker.
+      - name: Run zizmor
+        continue-on-error: true
+        run: zizmor --format plain .
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to 4 checkout steps across 2 workflows (prevents credential leakage via artifacts)
- Add `zizmor.yml` CI workflow that scans GitHub Actions on every PR touching workflow files:
  - Pinned to zizmor v1.23.1 via pipx
  - Pinned to ubuntu-24.04 runner
  - Passes `GH_TOKEN` for richer audits (scoped to `contents: read`, safe for fork PRs)
  - Uses `continue-on-error: true` at step level — **see follow-up note below**
  - `timeout-minutes: 5`
  - Includes `workflow_dispatch` for manual runs

**Follow-up: Remove `continue-on-error: true`**
The zizmor scan is currently informational-only to avoid blocking PRs on pre-existing findings. Once the remaining findings (template-injection, excessive-permissions, secrets-outside-env) are triaged and either fixed or explicitly accepted, `continue-on-error: true` should be removed to make zizmor a hard gate. This is tracked as part of the broader zizmor rollout project.

**Intentionally not changed:**
- `trigger-release-to-firebase.yml` — uses `peter-evans/create-pull-request`, needs git credentials
- `pr-notification.yml` — reusable workflow call, no checkout step

**Permissions unchanged** — existing workflow-level permissions left as-is to avoid CI breakage (follow-up for future hardening pass).

## Test plan
- [x] Verify CI/CD pipelines run successfully
- [ ] Confirm zizmor workflow runs after merge (new workflow — only triggers once merged to main)

## Rollback plan
Revert this PR.