### PR TITLE
feat: Add Shoppable Ads demo with Stripe payment integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,19 @@
+<!-- markdownlint-disable MD024 -->
 
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Shoppable Ads demo with Stripe payment integration
+- Custom placement builder for Shoppable Ads (account setup, attributes, execution)
+- RoktStripePaymentExtension SPM dependency
+- Pre-populated default attributes for easy Shoppable Ads testing
+- SDK event logging in Shoppable Ads execution view
+- Shoppable Ads-specific disclaimer in placement summary

--- a/README.md
+++ b/README.md
@@ -1,110 +1,92 @@
 # rokt-demo-ios
-Rokt Demo application is a sample app built to showcase Rokt SDK functionality. The purpose of this app is to showcase the functionality that Rokt provides in-app. This is demonstrated with examples of how Rokt’s partners are generating stronger revenue outcomes by providing a more personalized experience for each customer at scale. 
 
+Rokt Demo is a sample iOS app built to showcase Rokt SDK functionality. It demonstrates how Rokt's partners generate stronger revenue outcomes by providing personalized experiences for each customer at scale.
 
+## Features
 
-## Resident Experts
-- James Newman - <james.newman@rokt.com>
-- Thomson Thomas - <thomson.thomas@rokt.com>
-
-
+- **In-app Placements** — View examples of embedded and overlay placement experiences with live offers
+- **Custom Placement Builder** — Enter your Rokt account details to preview custom placements on a sample confirmation page
+- **Pre-defined Demos** — Branded partner confirmation pages (Heated, Stylus Commerce, Waveroom Supply Co)
+- **Shoppable Ads** — Test the Shoppable Ads experience with Stripe payment integration, configurable attributes, and SDK event logging
 
 ## Requirements
 
-XCode 15 and above. Project is configured to run on iOS 15.0 and above.
+Xcode 15 and above. The project is configured to run on iOS 15.0 and above.
 
-## Project architecture
+## Project Architecture
 
-This project is implemented based on MVVM pattern with SwiftUI. 
+This project is implemented using the MVVM pattern with SwiftUI.
 
-[SwiftUI](https://developer.apple.com/xcode/swiftui/) is a framework made by Apple to build user interfaces across all Apple platforms with the power of Swift. SwiftUI is a user interface toolkit that lets us design apps in a declarative way.
-MVVM stands for Model-View-ViewModel, an architecture pattern that is structured to separate program logic and user interface controls. It has Model, View and ViewModel separation. 
+[SwiftUI](https://developer.apple.com/xcode/swiftui/) is Apple's declarative UI framework. MVVM (Model-View-ViewModel) separates program logic from user interface controls.
 
-This project contains UI, Model, Services, Utils and Resources groups.
+The project is organized into the following groups:
 
-UI: View and ViewModels are located in the UI Group.
-
-Services & Model: Services represent the network logics of the application and model represents the data.
-
-Utils: are shared between Groups of the application.
-
-Resources: All the other resources of the application is located in Resources. 
+- **UI** — Views and ViewModels
+- **Model** — Data models for the placement library and demo items
+- **Service** — Network and business logic
+- **Utils** — Shared utilities and constants
+- **Resources** — App lifecycle, assets, and fonts
 
 ![UI diagram](diagram.png)
 
-## How to setup the environment?
+## How to Set Up the Environment
 
-- open RoktDemo.xcodeproj in Xcode
-- click File -> Packages -> Reset Package Caches in Xcode
-- click File -> Packages -> Resolve Package Versions in Xcode
+1. Open `RoktDemo.xcodeproj` in Xcode
+2. Go to File > Packages > Reset Package Caches
+3. Go to File > Packages > Resolve Package Versions
 
-## How to run locally?
+## How to Run Locally
 
-Open RoktDemo.xcodeproj in Xcode and click Run icon on top left of Xcode.
+Open `RoktDemo.xcodeproj` in Xcode and click the Run button (or press Cmd+R).
 
-## How to run tests locally?
+## How to Run Tests
 
-Select the RoktDemo scheme and press command + U, or Product -> Test menu on Xcode.
-Tests can be found in `RoktDemoTests` and `RoktDemoUIITests`.
+Select the `RoktDemo` scheme and press Cmd+U, or go to Product > Test in Xcode.
+Tests are located in `RoktDemoTests` and `RoktDemoUITests`.
 
-## Where are dependencies defined?
+## Dependencies
 
-[Swift Package Manager](https://www.swift.org/package-manager/) (SPM) is Apple's official dependency manager for Swift projects. SPM integrates directly with Xcode and automatically resolves dependencies, fetches source code, and manages package versions. All dependencies of this project are defined in the Xcode project file and managed through SPM. 
+All dependencies are managed via [Swift Package Manager](https://www.swift.org/package-manager/) (SPM), which integrates directly with Xcode.
 
-## What are project dependencies
-In this application, following dependencies are used: 
--  Rokt-Widget: [Rokt-Widget](https://docs.rokt.com/docs/developers/integration-guides/ios/overview) is Rokt iOS SDK. This app is built to showcase the functionality that this Rokt SDK provides in-app.  
--  Alamofire: [Alamofire](https://github.com/Alamofire/Alamofire) is an HTTP networking library written in Swift. This is used for networking part of the application.
--  SDWebImageSwiftUI: [SDWebImageSwiftUI](https://github.com/SDWebImage/SDWebImageSwiftUI) is a SwiftUI image loading framework. This is used for loading images in SwiftUI.
--  CodeScanner: [CodeScanner](https://github.com/twostraws/CodeScanner) CodeScanner is a SwiftUI framework that makes it easy to scan codes such as QR codes and barcodes.
+| Dependency | Description |
+|------------|-------------|
+| [Rokt-Widget](https://docs.rokt.com/developers/integration-guides/ios/overview) | Rokt iOS SDK — the core SDK this app demonstrates |
+| [RoktStripePaymentExtension](https://github.com/ROKT/rokt-stripe-payment-extension-ios) | Stripe payment integration for Shoppable Ads |
+| [Alamofire](https://github.com/Alamofire/Alamofire) | HTTP networking library |
+| [SDWebImageSwiftUI](https://github.com/SDWebImage/SDWebImageSwiftUI) | SwiftUI image loading framework |
+| [CodeScanner](https://github.com/twostraws/CodeScanner) | QR code and barcode scanner |
 
-## How to test point to a version of iOS SDK
-To point to a certain version:
-- Open RoktDemo.xcodeproj in Xcode
-- Select the project in the navigator, then select the RoktDemo target
-- Go to the "Package Dependencies" tab
-- Find "rokt-sdk-ios" and click the version dropdown
-- Select "Up to Next Major Version" and specify the minimum version (e.g., `4.14.1`) or choose a specific version
-- Alternatively, you can update the version requirement in the project.pbxproj file by changing the `minimumVersion` value for the Rokt-Widget package reference
+## How to Point to a Specific SDK Version
 
-## How to release the app
+1. Open `RoktDemo.xcodeproj` in Xcode
+2. Select the project in the navigator, then select the RoktDemo target
+3. Go to the "Package Dependencies" tab
+4. Find "rokt-sdk-ios" and click the version dropdown
+5. Select "Up to Next Major Version" and specify the minimum version, or choose a specific version
+
+## How to Release
+
 > [!NOTE]
-> Testers in `TESTING_GROUPS` repo secret will get the new build.
+> Testers in the `TESTING_GROUPS` repo secret will receive the new build.
 
-- Update `Version` and `Build` in RoktDemo target
-- Commit & push
-- Dispatch the workflow `Distribute to Firebase` from the Actions tab on GitHub
+1. Update `Version` and `Build` in the RoktDemo target
+2. Commit and push
+3. Dispatch the `Distribute to Firebase` workflow from the Actions tab on GitHub
 
-### Automated Release Pipeline
-The SDK can be released via the **Mobile Release Pipeline**. Follow the instructions in the Mobile Release Pipeline repo to release. You can still release the app manually by following the steps in the previous section.
+The app can also be released via the **Mobile Release Pipeline** — follow the instructions in the Mobile Release Pipeline repo.
 
-### Note
+## Branches
 
-To get Appstoreconnect user access, please ask it from <dj.seo@rokt.com>, <danial.motahari@rokt.com> or <thomson.thomas@rokt.com>
+- **main** — Primary branch for development
+- **release-\*** — Production release branches
+- **feat/\*** — Feature branches
 
-## FAQ
+## Troubleshooting
 
-### What are the branches?
+If something is not working, try:
 
-The main branches of these repository includes: **main**, **Release-** and **Features branches**
-
-* **main** - Master branch which currently is not used
-* **release branches** - Branches with **release-** prefix are considered production branches. After every push to this branch tests are run to ensure no breaking changes are allowed and after approval. Releasing to TestFlight could be enabled after all the tests passes. 
-* **feature branches** - All other branches are considered feature branches. After every push to this branch tests are run to ensure no breaking changes are allowed.
-
-### What are the versions?
-We are using semantic versioning starting with version 1.0.0. Each new feature requires incrementing minor version and bracking changes require incrementing major version. 
-Currently we have following release branches.
-
-* **release-1.x** - The first version of Demo application
-* **release-1.1.x** - The PreDefined brand demos added
-* **release-1.2.x** - Layouts preview and QR code scan support added
-
-### Something is not working, what do I do?
-
-In case you run into any problems you can try:
-
-* Clean the build folder of the project. Select menu: Product -> Clean Build Folder on Xcode
+- Clean the build folder: Product > Clean Build Folder in Xcode
+- Reset package caches: File > Packages > Reset Package Caches
 
 ## License
 

--- a/RoktDemo.xcodeproj/project.pbxproj
+++ b/RoktDemo.xcodeproj/project.pbxproj
@@ -117,6 +117,15 @@
 		2A1B2C3D4E5F6A7B8C9D0E1F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 2A1B2C3D4E5F6A7B8C9D0E2F /* Alamofire */; };
 		2A1B2C3D4E5F6A7B8C9D0E3F /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2A1B2C3D4E5F6A7B8C9D0E4F /* SDWebImageSwiftUI */; };
 		2A1B2C3D4E5F6A7B8C9D0E5F /* Rokt-Widget in Frameworks */ = {isa = PBXBuildFile; productRef = 2A1B2C3D4E5F6A7B8C9D0E6F /* Rokt-Widget */; };
+		3B0A1C2D3E4F5A6B7C8D9E0F /* RoktStripePaymentExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 3B0A1C2D3E4F5A6B7C8D9E1F /* RoktStripePaymentExtension */; };
+		4C0A00110000000100000001 /* ShoppableAdsDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00010000000100000001 /* ShoppableAdsDefaults.swift */; };
+		4C0A00120000000100000001 /* ShoppableAdsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00020000000100000001 /* ShoppableAdsModel.swift */; };
+		4C0A00130000000100000001 /* ShoppableAdsAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00030000000100000001 /* ShoppableAdsAccountViewModel.swift */; };
+		4C0A00140000000100000001 /* ShoppableAdsAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00040000000100000001 /* ShoppableAdsAccountView.swift */; };
+		4C0A00150000000100000001 /* ShoppableAdsAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00050000000100000001 /* ShoppableAdsAttributesViewModel.swift */; };
+		4C0A00160000000100000001 /* ShoppableAdsAttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00060000000100000001 /* ShoppableAdsAttributesView.swift */; };
+		4C0A00170000000100000001 /* ShoppableAdsExecutionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00070000000100000001 /* ShoppableAdsExecutionViewModel.swift */; };
+		4C0A00180000000100000001 /* ShoppableAdsExecutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A00080000000100000001 /* ShoppableAdsExecutionView.swift */; };
 		5899226B2613F63800A58DA3 /* Font+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5899226A2613F63800A58DA3 /* Font+Extensions.swift */; };
 		589922702613F67A00A58DA3 /* ButtonDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5899226F2613F67A00A58DA3 /* ButtonDefault.swift */; };
 		589922792613F75800A58DA3 /* ButtonDefaultOutlined.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589922782613F75800A58DA3 /* ButtonDefaultOutlined.swift */; };
@@ -244,6 +253,14 @@
 		25F84788260C348A0067B515 /* RoktDemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoktDemoUITests.swift; sourceTree = "<group>"; };
 		25F8478A260C348A0067B515 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		25FA8C662BE1D5CB00E750A6 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
+		4C0A00010000000100000001 /* ShoppableAdsDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsDefaults.swift; sourceTree = "<group>"; };
+		4C0A00020000000100000001 /* ShoppableAdsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsModel.swift; sourceTree = "<group>"; };
+		4C0A00030000000100000001 /* ShoppableAdsAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsAccountViewModel.swift; sourceTree = "<group>"; };
+		4C0A00040000000100000001 /* ShoppableAdsAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsAccountView.swift; sourceTree = "<group>"; };
+		4C0A00050000000100000001 /* ShoppableAdsAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsAttributesViewModel.swift; sourceTree = "<group>"; };
+		4C0A00060000000100000001 /* ShoppableAdsAttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsAttributesView.swift; sourceTree = "<group>"; };
+		4C0A00070000000100000001 /* ShoppableAdsExecutionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsExecutionViewModel.swift; sourceTree = "<group>"; };
+		4C0A00080000000100000001 /* ShoppableAdsExecutionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsExecutionView.swift; sourceTree = "<group>"; };
 		5899226A2613F63800A58DA3 /* Font+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extensions.swift"; sourceTree = "<group>"; };
 		5899226F2613F67A00A58DA3 /* ButtonDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonDefault.swift; sourceTree = "<group>"; };
 		589922782613F75800A58DA3 /* ButtonDefaultOutlined.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonDefaultOutlined.swift; sourceTree = "<group>"; };
@@ -260,6 +277,7 @@
 		7EAD606D2DCA5470009EC6DB /* LayoutDemoUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutDemoUIView.swift; sourceTree = "<group>"; };
 		7EAD606F2DCA5932009EC6DB /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		7EAD60722DCA59FD009EC6DB /* UIColor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
+		B35D9F9B2F8D3FBB00209B98 /* RoktDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RoktDemo.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -271,6 +289,7 @@
 				2A1B2C3D4E5F6A7B8C9D0E1F /* Alamofire in Frameworks */,
 				2A1B2C3D4E5F6A7B8C9D0E3F /* SDWebImageSwiftUI in Frameworks */,
 				2A1B2C3D4E5F6A7B8C9D0E5F /* Rokt-Widget in Frameworks */,
+				3B0A1C2D3E4F5A6B7C8D9E0F /* RoktStripePaymentExtension in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -329,6 +348,7 @@
 				251E32D5274B0D2200308A18 /* Walkthrough */,
 				251E32D6274B0E8B00308A18 /* Custom */,
 				251E32F5274B452500308A18 /* Predefined */,
+				4C0A00200000000100000001 /* ShoppableAds */,
 				251E32DC274B0F6700308A18 /* Error */,
 				256EB75F261C0F7F00B959EF /* DemoLibraryView.swift */,
 				256E3D3D2623DFE000639FE0 /* DemoLibraryViewModel.swift */,
@@ -470,6 +490,7 @@
 				251E3308274F09FA00308A18 /* CustomConfiguration */,
 				251E3307274F09E200308A18 /* DefaultPlacement */,
 				251E3306274F09B800308A18 /* PreDefinedScreen */,
+				4C0A00210000000100000001 /* ShoppableAds */,
 				256EB76E261C1CB700B959EF /* DemoItemModel.swift */,
 			);
 			path = DemoItems;
@@ -599,6 +620,7 @@
 		25F84765260C34880067B515 /* RoktDemo */ = {
 			isa = PBXGroup;
 			children = (
+				B35D9F9B2F8D3FBB00209B98 /* RoktDemo.entitlements */,
 				5899229B261420B500A58DA3 /* Service */,
 				5899228826141F2100A58DA3 /* Model */,
 				589873FC2612C38F00C904E8 /* Utils */,
@@ -644,6 +666,28 @@
 				25FA8C662BE1D5CB00E750A6 /* SettingView.swift */,
 			);
 			path = Setting;
+			sourceTree = "<group>";
+		};
+		4C0A00200000000100000001 /* ShoppableAds */ = {
+			isa = PBXGroup;
+			children = (
+				4C0A00030000000100000001 /* ShoppableAdsAccountViewModel.swift */,
+				4C0A00040000000100000001 /* ShoppableAdsAccountView.swift */,
+				4C0A00050000000100000001 /* ShoppableAdsAttributesViewModel.swift */,
+				4C0A00060000000100000001 /* ShoppableAdsAttributesView.swift */,
+				4C0A00070000000100000001 /* ShoppableAdsExecutionViewModel.swift */,
+				4C0A00080000000100000001 /* ShoppableAdsExecutionView.swift */,
+			);
+			path = ShoppableAds;
+			sourceTree = "<group>";
+		};
+		4C0A00210000000100000001 /* ShoppableAds */ = {
+			isa = PBXGroup;
+			children = (
+				4C0A00010000000100000001 /* ShoppableAdsDefaults.swift */,
+				4C0A00020000000100000001 /* ShoppableAdsModel.swift */,
+			);
+			path = ShoppableAds;
 			sourceTree = "<group>";
 		};
 		589873F82612BF1100C904E8 /* UI */ = {
@@ -745,6 +789,7 @@
 				2A1B2C3D4E5F6A7B8C9D0E2F /* Alamofire */,
 				2A1B2C3D4E5F6A7B8C9D0E4F /* SDWebImageSwiftUI */,
 				2A1B2C3D4E5F6A7B8C9D0E6F /* Rokt-Widget */,
+				3B0A1C2D3E4F5A6B7C8D9E1F /* RoktStripePaymentExtension */,
 			);
 			productName = RoktDemo;
 			productReference = 25F84763260C34880067B515 /* RoktDemo.app */;
@@ -822,6 +867,7 @@
 				2A1B2C3D4E5F6A7B8C9D0E1E /* XCRemoteSwiftPackageReference "Alamofire" */,
 				2A1B2C3D4E5F6A7B8C9D0E3E /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				2A1B2C3D4E5F6A7B8C9D0E5E /* XCRemoteSwiftPackageReference "rokt-sdk-ios" */,
+				3B0A1C2D3E4F5A6B7C8D9E2E /* XCRemoteSwiftPackageReference "rokt-stripe-payment-extension-ios" */,
 			);
 			productRefGroup = 25F84764260C34880067B515 /* Products */;
 			projectDirPath = "";
@@ -950,6 +996,14 @@
 				589922792613F75800A58DA3 /* ButtonDefaultOutlined.swift in Sources */,
 				5899228426141EF900A58DA3 /* AboutRoktView.swift in Sources */,
 				25D1D72226DF5E7B0045D579 /* KeyboardModifier.swift in Sources */,
+				4C0A00110000000100000001 /* ShoppableAdsDefaults.swift in Sources */,
+				4C0A00120000000100000001 /* ShoppableAdsModel.swift in Sources */,
+				4C0A00130000000100000001 /* ShoppableAdsAccountViewModel.swift in Sources */,
+				4C0A00140000000100000001 /* ShoppableAdsAccountView.swift in Sources */,
+				4C0A00150000000100000001 /* ShoppableAdsAttributesViewModel.swift in Sources */,
+				4C0A00160000000100000001 /* ShoppableAdsAttributesView.swift in Sources */,
+				4C0A00170000000100000001 /* ShoppableAdsExecutionViewModel.swift in Sources */,
+				4C0A00180000000100000001 /* ShoppableAdsExecutionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1158,6 +1212,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RoktDemo/RoktDemo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 367;
@@ -1186,6 +1241,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RoktDemo/RoktDemo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 367;
@@ -1365,6 +1421,14 @@
 				minimumVersion = 5.0.0;
 			};
 		};
+		3B0A1C2D3E4F5A6B7C8D9E2E /* XCRemoteSwiftPackageReference "rokt-stripe-payment-extension-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ROKT/rokt-stripe-payment-extension-ios.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1387,6 +1451,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2A1B2C3D4E5F6A7B8C9D0E5E /* XCRemoteSwiftPackageReference "rokt-sdk-ios" */;
 			productName = "Rokt-Widget";
+		};
+		3B0A1C2D3E4F5A6B7C8D9E1F /* RoktStripePaymentExtension */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B0A1C2D3E4F5A6B7C8D9E2E /* XCRemoteSwiftPackageReference "rokt-stripe-payment-extension-ios" */;
+			productName = RoktStripePaymentExtension;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RoktDemo/Model/DemoLibrary/DemoItems/ShoppableAds/ShoppableAdsDefaults.swift
+++ b/RoktDemo/Model/DemoLibrary/DemoItems/ShoppableAds/ShoppableAdsDefaults.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct ShoppableAdsDefaults {
+    static let tagID = "3068704822624787054"
+    static let viewName = "StgRoktShoppableAds"
+    static let stripePublishableKey = "" // User must provide
+    static let applePayMerchantId = "merchant.rokt.demoapp"
+
+    static let attributes: [String: String] = [
+        "email": "jenny.smith@example.com",
+        "firstname": "Jenny",
+        "lastname": "Smith",
+        "confirmationref": "ORD-12345",
+        "country": "US",
+        "sandbox": "true",
+        "shippingaddress1": "123 Main St",
+        "shippingaddress2": "Apt 4B",
+        "shippingcity": "New York",
+        "shippingstate": "NY",
+        "shippingzipcode": "10001",
+        "shippingcountry": "US",
+        "billingzipcode": "07762",
+        "paymenttype": "ApplePay",
+        "last4digits": "4444",
+    ]
+}

--- a/RoktDemo/Model/DemoLibrary/DemoItems/ShoppableAds/ShoppableAdsModel.swift
+++ b/RoktDemo/Model/DemoLibrary/DemoItems/ShoppableAds/ShoppableAdsModel.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+class ShoppableAdsModel: DemoItemModel {
+    let defaultTagID: String
+    let defaultViewName: String
+    let defaultStripePublishableKey: String
+    let defaultAttributes: [String: String]
+
+    init(title: String,
+         shortDescription: String,
+         longDescription: String?,
+         iconURL: String,
+         defaultTagID: String,
+         defaultViewName: String,
+         defaultStripePublishableKey: String,
+         defaultAttributes: [String: String]) {
+        self.defaultTagID = defaultTagID
+        self.defaultViewName = defaultViewName
+        self.defaultStripePublishableKey = defaultStripePublishableKey
+        self.defaultAttributes = defaultAttributes
+        super.init(title: title,
+                   shortDescription: shortDescription,
+                   longDescription: longDescription,
+                   iconURL: iconURL)
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case defaultTagID
+        case defaultViewName
+        case defaultStripePublishableKey
+        case defaultAttributes
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        defaultTagID = try container.decodeIfPresent(String.self, forKey: .defaultTagID) ?? ShoppableAdsDefaults.tagID
+        defaultViewName = try container.decodeIfPresent(String.self, forKey: .defaultViewName) ?? ShoppableAdsDefaults.viewName
+        defaultStripePublishableKey = try container.decodeIfPresent(String.self, forKey: .defaultStripePublishableKey) ?? ShoppableAdsDefaults.stripePublishableKey
+        defaultAttributes = try container.decodeIfPresent([String: String].self, forKey: .defaultAttributes) ?? ShoppableAdsDefaults.attributes
+        try super.init(from: decoder)
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(defaultTagID, forKey: .defaultTagID)
+        try container.encode(defaultViewName, forKey: .defaultViewName)
+        try container.encode(defaultStripePublishableKey, forKey: .defaultStripePublishableKey)
+        try container.encode(defaultAttributes, forKey: .defaultAttributes)
+        try super.encode(to: encoder)
+    }
+
+    // MARK: - Hashable
+
+    override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(defaultTagID)
+        hasher.combine(defaultViewName)
+        hasher.combine(defaultStripePublishableKey)
+    }
+
+    static func == (lhs: ShoppableAdsModel, rhs: ShoppableAdsModel) -> Bool {
+        return lhs.title == rhs.title &&
+            lhs.shortDescription == rhs.shortDescription &&
+            lhs.defaultTagID == rhs.defaultTagID &&
+            lhs.defaultViewName == rhs.defaultViewName
+    }
+
+    // MARK: - Factory
+
+    static func defaultItem() -> ShoppableAdsModel {
+        ShoppableAdsModel(
+            title: "Shoppable Ads",
+            shortDescription: "Test the Shoppable Ads experience with Stripe payment integration. Enter your account details and see live shoppable ad placements.",
+            longDescription: "For SDK integration testing\n\nThis interactive demo lets you configure and test the Shoppable Ads feature.\n\nYou'll need a Rokt account ID (tag ID) and a Stripe publishable key to test payments.\n\nShoppable Ads always display as an overlay experience.\n",
+            iconURL: "ShoppableAds",
+            defaultTagID: ShoppableAdsDefaults.tagID,
+            defaultViewName: ShoppableAdsDefaults.viewName,
+            defaultStripePublishableKey: ShoppableAdsDefaults.stripePublishableKey,
+            defaultAttributes: ShoppableAdsDefaults.attributes
+        )
+    }
+}

--- a/RoktDemo/Resources/Assets.xcassets/ShoppableAds.imageset/Contents.json
+++ b/RoktDemo/Resources/Assets.xcassets/ShoppableAds.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_shoppable_ads.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/RoktDemo/Resources/Assets.xcassets/ShoppableAds.imageset/ic_shoppable_ads.svg
+++ b/RoktDemo/Resources/Assets.xcassets/ShoppableAds.imageset/ic_shoppable_ads.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Shopping cart body -->
+  <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"/>
+  <line x1="3" y1="6" x2="21" y2="6"/>
+  <!-- Plus badge indicating shoppable/purchasable -->
+  <path d="M12 11v6M9 14h6"/>
+</svg>

--- a/RoktDemo/RoktDemo.entitlements
+++ b/RoktDemo/RoktDemo.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+		<string>merchant.rokt.demoapp</string>
+	</array>
+</dict>
+</plist>

--- a/RoktDemo/UI/Common/Views/AlertView.swift
+++ b/RoktDemo/UI/Common/Views/AlertView.swift
@@ -60,6 +60,10 @@ As you progress, try interacting with the Rokt placements by tapping "Yes please
 As you progress, try interacting with the Rokt placements by tapping "Yes please" or "No thanks". To progress to the next placement type, tap "NEXT" at the top right hand corner of the screen.
 \n\nNo personal and device data will be captured or stored.
 """
+    static let shoppableAdsTemplate = """
+You are about to see a Shoppable Ads experience. Browse products, select options, and interact with the purchase flow.
+\n\nNo personal, account, or device data will be captured or stored.
+"""
 }
 
 

--- a/RoktDemo/UI/Placement Demo/DemoLibraryViewModel.swift
+++ b/RoktDemo/UI/Placement Demo/DemoLibraryViewModel.swift
@@ -48,5 +48,7 @@ class DemoLibraryViewModel: ObservableObject {
         demoItems.append(demo.preDefinedScreen1)
         demoItems.append(demo.preDefinedScreen2)
         demoItems.append(demo.preDefinedScreen3)
+        // Add hardcoded Shoppable Ads demo item (iOS-only, not from backend)
+        demoItems.append(ShoppableAdsModel.defaultItem())
     }
 }

--- a/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAccountView.swift
+++ b/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAccountView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import Rokt_Widget
+import RoktStripePaymentExtension
+
+struct ShoppableAdsAccountView: View {
+    @ObservedObject var viewModel: ShoppableAdsAccountViewModel
+
+    @State var moveToNextView = false
+    @Binding var popToRootView: Bool
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Step 1/2")
+                        .font(.defaultFont(.text))
+                        .foregroundColor(.subtitleColor)
+
+                    Text("Account details")
+                        .font(.defaultBoldFont(.header2))
+                        .foregroundColor(.textColor)
+
+                    DetailTextView(
+                        text: "Enter your Rokt Account ID, Stripe Publishable Key, and the View Name for the Shoppable Ads placement you'd like to preview.",
+                        font: .defaultFont(.subtitle1))
+
+                    DetailTextFieldView(
+                        title: "Account ID",
+                        textHolder: $viewModel.tagID,
+                        errorMessage: $viewModel.tagIDError,
+                        hasError: $viewModel.tagIDHasError)
+
+                    DetailTextFieldView(
+                        title: "Stripe Publishable Key",
+                        textHolder: $viewModel.stripePublishableKey,
+                        errorMessage: $viewModel.stripeKeyError,
+                        hasError: $viewModel.stripeKeyHasError)
+
+                    DetailTextFieldView(
+                        title: "View Name",
+                        textHolder: $viewModel.viewName)
+
+                    NavigationLink(
+                        destination: ShoppableAdsAttributesView(
+                            viewModel: ShoppableAdsAttributesViewModel(
+                                accountData: viewModel.getAccountData()),
+                            popToRootView: $popToRootView),
+                        isActive: $moveToNextView) {
+                        Text("")
+                    }.hidden()
+                }.padding()
+            }
+            .modifier(NavigationBarBlackWithButton(
+                title: "",
+                trailingButtonTitle: Constants.Strings.exitDemo,
+                trailingButtonAction: {
+                    popToRootView = false
+                }))
+
+            Button(Constants.Strings.continueDemo) {
+                if viewModel.isValidToContinue() {
+                    // Initialize Rokt SDK and register Stripe payment extension early
+                    Rokt.initWith(roktTagId: viewModel.tagID)
+                    if let stripeExt = RoktStripePaymentExtension(applePayMerchantId: ShoppableAdsDefaults.applePayMerchantId) {
+                        Rokt.registerPaymentExtension(stripeExt, config: [
+                            "stripeKey": viewModel.stripePublishableKey
+                        ])
+                    }
+                    moveToNextView = true
+                }
+            }
+            .buttonStyle(ButtonDefault())
+            .background(Color.white)
+            .padding(EdgeInsets(top: 10, leading: 10, bottom: 30, trailing: 10))
+        }
+        .keyboardSafe()
+        .animation(.easeOut(duration: 0.19))
+        .background(Color.gray3)
+        .edgesIgnoringSafeArea([.bottom])
+    }
+}
+
+struct ShoppableAdsAccountView_Previews: PreviewProvider {
+    static var previews: some View {
+        ShoppableAdsAccountView(
+            viewModel: ShoppableAdsAccountViewModel(),
+            popToRootView: .constant(true))
+    }
+}

--- a/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAccountViewModel.swift
+++ b/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAccountViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+class ShoppableAdsAccountViewModel: ObservableObject {
+    @Published var tagID: String
+    @Published var tagIDHasError: Bool = false
+    @Published var tagIDError: String = "Account ID can't be empty!"
+    @Published var stripePublishableKey: String
+    @Published var stripeKeyHasError: Bool = false
+    @Published var stripeKeyError: String = "Stripe Publishable Key can't be empty!"
+    @Published var viewName: String
+    init() {
+        tagID = ShoppableAdsDefaults.tagID
+        stripePublishableKey = ShoppableAdsDefaults.stripePublishableKey
+        viewName = ShoppableAdsDefaults.viewName
+    }
+
+    func isValidToContinue() -> Bool {
+        tagIDHasError = ValidationService.isEmpty(tagID)
+        stripeKeyHasError = ValidationService.isEmpty(stripePublishableKey)
+        return !tagIDHasError && !stripeKeyHasError
+    }
+
+    func getAccountData() -> ShoppableAdsAccountData {
+        ShoppableAdsAccountData(
+            tagID: tagID,
+            stripePublishableKey: stripePublishableKey,
+            viewName: viewName
+        )
+    }
+}

--- a/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAttributesView.swift
+++ b/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAttributesView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct ShoppableAdsAttributesView: View {
+    @ObservedObject var viewModel: ShoppableAdsAttributesViewModel
+
+    @State var moveToNextView = false
+    @Binding var popToRootView: Bool
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Step 2/2")
+                        .font(.defaultFont(.text))
+                        .foregroundColor(.subtitleColor)
+
+                    Text("Attributes")
+                        .font(.defaultBoldFont(.header2))
+                        .foregroundColor(.textColor)
+
+                    DetailTextView(
+                        text: "Configure the attributes sent to the Shoppable Ads placement. Basic fields are pre-populated with test defaults. Add additional attributes as needed.",
+                        font: .defaultFont(.subtitle1))
+
+                    // Basic fields section
+                    Text("Basic Fields")
+                        .font(.defaultBoldFont(.subtitle1))
+                        .foregroundColor(.titleColor)
+                        .padding(.top, 8)
+
+                    DetailTextFieldView(title: "Email", textHolder: $viewModel.email)
+                    DetailTextFieldView(title: "First Name", textHolder: $viewModel.firstname)
+                    DetailTextFieldView(title: "Last Name", textHolder: $viewModel.lastname)
+                    DetailTextFieldView(title: "Confirmation Ref", textHolder: $viewModel.confirmationref)
+                    DetailTextFieldView(title: "Country", textHolder: $viewModel.country)
+                    DetailTextFieldView(title: "Sandbox", textHolder: $viewModel.sandbox)
+
+                    // Additional attributes section
+                    Text("Additional Attributes")
+                        .font(.defaultBoldFont(.subtitle1))
+                        .foregroundColor(.titleColor)
+                        .padding(.top, 8)
+
+                    ForEach(viewModel.additionalAttributes.indices, id: \.self) { index in
+                        ShoppableAdsAttributeRow(
+                            model: Binding(
+                                get: { viewModel.additionalAttributes[index] },
+                                set: { viewModel.additionalAttributes[index] = $0 }),
+                            onDelete: {
+                                viewModel.removeAttribute(at: index)
+                            })
+                    }
+
+                    // Add Attribute button
+                    Button(action: {
+                        viewModel.addAttribute()
+                    }, label: {
+                        HStack {
+                            Spacer()
+                            Image(systemName: "plus.circle")
+                                .foregroundColor(viewModel.canAddMoreAttributes ? .black : .gray)
+                            Text("Add Attribute")
+                                .foregroundColor(viewModel.canAddMoreAttributes ? .black : .gray)
+                            Spacer()
+                        }
+                        .padding()
+                        .background(viewModel.canAddMoreAttributes ? Color.white : Color.gray.opacity(0.3))
+                        .cornerRadius(8)
+                    })
+                    .disabled(!viewModel.canAddMoreAttributes)
+                    .padding(.top, 10)
+
+                    NavigationLink(
+                        destination: ShoppableAdsExecutionView(
+                            viewModel: ShoppableAdsExecutionViewModel(
+                                accountData: viewModel.accountData,
+                                attributes: viewModel.getAllAttributes()),
+                            popToRootView: $popToRootView),
+                        isActive: $moveToNextView) {
+                        Text("")
+                    }.hidden()
+                }.padding()
+            }
+            .modifier(NavigationBarBlackWithButton(
+                title: "",
+                trailingButtonTitle: Constants.Strings.exitDemo,
+                trailingButtonAction: {
+                    popToRootView = false
+                }))
+
+            Button("Execute Shoppable Ads") {
+                moveToNextView = true
+            }
+            .buttonStyle(ButtonDefault())
+            .background(Color.white)
+            .padding(EdgeInsets(top: 10, leading: 10, bottom: 30, trailing: 10))
+        }
+        .keyboardSafe()
+        .animation(.easeOut(duration: 0.16))
+        .background(Color.gray3)
+        .edgesIgnoringSafeArea([.bottom])
+    }
+}
+
+private struct ShoppableAdsAttributeRow: View {
+    @Binding var model: KeyValue
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            DetailTextFieldView(title: "Key", textHolder: $model.key)
+            DetailTextFieldView(title: "Value", textHolder: $model.value)
+            Button(action: onDelete) {
+                Image(systemName: "minus.circle.fill")
+                    .foregroundColor(.errorColor)
+                    .padding(.top, 24)
+            }
+        }
+    }
+}
+
+struct ShoppableAdsAttributesView_Previews: PreviewProvider {
+    static var previews: some View {
+        ShoppableAdsAttributesView(
+            viewModel: ShoppableAdsAttributesViewModel(
+                accountData: ShoppableAdsAccountData(
+                    tagID: ShoppableAdsDefaults.tagID,
+                    stripePublishableKey: "",
+                    viewName: ShoppableAdsDefaults.viewName)),
+            popToRootView: .constant(true))
+    }
+}

--- a/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAttributesViewModel.swift
+++ b/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsAttributesViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+// MARK: - Data transfer struct between Account and Attributes screens
+
+struct ShoppableAdsAccountData {
+    let tagID: String
+    let stripePublishableKey: String
+    let viewName: String
+}
+
+// MARK: - ViewModel
+
+class ShoppableAdsAttributesViewModel: ObservableObject {
+    private static let maxAttributesCount = 30
+
+    let accountData: ShoppableAdsAccountData
+
+    // Pre-populated basic fields
+    @Published var email: String
+    @Published var firstname: String
+    @Published var lastname: String
+    @Published var confirmationref: String
+    @Published var country: String
+    @Published var sandbox: String
+
+    // Dynamic additional attributes
+    @Published var additionalAttributes: [KeyValue] = []
+
+    init(accountData: ShoppableAdsAccountData) {
+        self.accountData = accountData
+        let defaults = ShoppableAdsDefaults.attributes
+        email = defaults["email"] ?? ""
+        firstname = defaults["firstname"] ?? ""
+        lastname = defaults["lastname"] ?? ""
+        confirmationref = defaults["confirmationref"] ?? ""
+        country = defaults["country"] ?? ""
+        sandbox = defaults["sandbox"] ?? ""
+
+        // Pre-populate remaining defaults as additional attributes
+        let basicKeys: Set<String> = ["email", "firstname", "lastname", "confirmationref", "country", "sandbox"]
+        for (key, value) in defaults where !basicKeys.contains(key) {
+            additionalAttributes.append(KeyValue(key: key, value: value))
+        }
+    }
+
+    func addAttribute() {
+        guard additionalAttributes.count < Self.maxAttributesCount else { return }
+        additionalAttributes.append(KeyValue(key: "", value: ""))
+    }
+
+    func removeAttribute(at index: Int) {
+        guard index >= 0 && index < additionalAttributes.count else { return }
+        additionalAttributes.remove(at: index)
+    }
+
+    var canAddMoreAttributes: Bool {
+        additionalAttributes.count < Self.maxAttributesCount
+    }
+
+    func getAllAttributes() -> [String: String] {
+        var attrs: [String: String] = [:]
+        if !email.isEmpty { attrs["email"] = email }
+        if !firstname.isEmpty { attrs["firstname"] = firstname }
+        if !lastname.isEmpty { attrs["lastname"] = lastname }
+        if !confirmationref.isEmpty { attrs["confirmationref"] = confirmationref }
+        if !country.isEmpty { attrs["country"] = country }
+        if !sandbox.isEmpty { attrs["sandbox"] = sandbox }
+        for kv in additionalAttributes where !kv.key.isEmpty && !kv.value.isEmpty {
+            attrs[kv.key] = kv.value
+        }
+        return attrs
+    }
+}

--- a/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsExecutionView.swift
+++ b/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsExecutionView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct ShoppableAdsExecutionView: View {
+    @ObservedObject var viewModel: ShoppableAdsExecutionViewModel
+    @Binding var popToRootView: Bool
+
+    @State private var hasExecuted = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Status section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Status")
+                    .font(.defaultBoldFont(.header2))
+                    .foregroundColor(.titleColor)
+
+                Text(viewModel.statusMessage)
+                    .font(.defaultFont(.text))
+                    .foregroundColor(.textColor)
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white)
+                    .border(Color.borderColor, width: 1)
+            }
+            .padding()
+
+            // Event log section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("SDK Events")
+                    .font(.defaultBoldFont(.subtitle1))
+                    .foregroundColor(.titleColor)
+                    .padding(.horizontal)
+
+                if viewModel.eventLog.isEmpty {
+                    Text("Waiting for events...")
+                        .font(.defaultFont(.subtitle2))
+                        .foregroundColor(.subtitleColor)
+                        .padding()
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(viewModel.eventLog.indices, id: \.self) { index in
+                                HStack(spacing: 8) {
+                                    Text("\(index + 1).")
+                                        .font(.defaultFont(.subtitle2))
+                                        .foregroundColor(.subtitleColor)
+                                    Text(viewModel.eventLog[index])
+                                        .font(.defaultFont(.text))
+                                        .foregroundColor(.textColor)
+                                }
+                                .padding(.horizontal)
+                                .padding(.vertical, 4)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 200)
+                    .background(Color.white)
+                    .border(Color.borderColor, width: 1)
+                    .padding(.horizontal)
+                }
+            }
+
+            Spacer()
+
+            // Info note
+            Text("The Shoppable Ads overlay is presented by the Rokt SDK automatically on top of this view.")
+                .font(.defaultFont(.subtitle2))
+                .foregroundColor(.subtitleColor)
+                .multilineTextAlignment(.center)
+                .padding()
+        }
+        .onAppear {
+            guard !hasExecuted else { return }
+            hasExecuted = true
+            viewModel.executeShoppableAds()
+        }
+        .background(Color.gray3)
+        .edgesIgnoringSafeArea([.bottom])
+        .modifier(NavigationBarBlackWithButton(
+            title: "Shoppable Ads",
+            trailingButtonTitle: Constants.Strings.exitDemo,
+            trailingButtonAction: {
+                popToRootView = false
+            }))
+    }
+}
+
+struct ShoppableAdsExecutionView_Previews: PreviewProvider {
+    static var previews: some View {
+        ShoppableAdsExecutionView(
+            viewModel: ShoppableAdsExecutionViewModel(
+                accountData: ShoppableAdsAccountData(
+                    tagID: ShoppableAdsDefaults.tagID,
+                    stripePublishableKey: "pk_test_example",
+                    viewName: ShoppableAdsDefaults.viewName),
+                attributes: ShoppableAdsDefaults.attributes),
+            popToRootView: .constant(true))
+    }
+}

--- a/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsExecutionViewModel.swift
+++ b/RoktDemo/UI/Placement Demo/ShoppableAds/ShoppableAdsExecutionViewModel.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Rokt_Widget
+
+class ShoppableAdsExecutionViewModel: ObservableObject {
+    let accountData: ShoppableAdsAccountData
+    let attributes: [String: String]
+
+    @Published var statusMessage: String = "Selecting Shoppable Ads..."
+    @Published var eventLog: [String] = []
+
+    init(accountData: ShoppableAdsAccountData, attributes: [String: String]) {
+        self.accountData = accountData
+        self.attributes = attributes
+    }
+
+    func executeShoppableAds() {
+        statusMessage = "Selecting Shoppable Ads..."
+
+        // SDK init and Stripe registration already done in ShoppableAdsAccountView
+        Rokt.selectShoppableAds(
+            identifier: accountData.viewName,
+            attributes: attributes
+        ) { [weak self] event in
+            DispatchQueue.main.async {
+                self?.handleEvent(event)
+            }
+        }
+    }
+
+    private func handleEvent(_ event: RoktEvent) {
+        switch event {
+        case is RoktEvent.PlacementReady:
+            statusMessage = "Placement displayed"
+            eventLog.append("PlacementReady")
+        case is RoktEvent.PlacementClosed:
+            eventLog.append("PlacementClosed")
+        case let e as RoktEvent.CartItemInstantPurchase:
+            eventLog.append("Purchase: \(e.catalogItemId)")
+        case let e as RoktEvent.CartItemInstantPurchaseFailure:
+            eventLog.append("PurchaseFailed: \(e.error ?? "unknown")")
+        case is RoktEvent.InstantPurchaseDismissal:
+            eventLog.append("Dismissed")
+        default:
+            eventLog.append("\(type(of: event))")
+        }
+    }
+}

--- a/RoktDemo/UI/Placement Demo/Summary/DemoItemSummaryView.swift
+++ b/RoktDemo/UI/Placement Demo/Summary/DemoItemSummaryView.swift
@@ -73,6 +73,10 @@ struct DemoItemSummaryView: View {
         }
         else if let model = viewModel.model as? PreDefinedScreen3Model {
             return AnyView(PreDefined3View(viewModel: PreDefinedViewModel(model: model), popToRootView: $pushActive))
+        } else if viewModel.model is ShoppableAdsModel {
+            return AnyView(ShoppableAdsAccountView(
+                viewModel: ShoppableAdsAccountViewModel(),
+                popToRootView: $pushActive))
         }
         return AnyView(EmptyView())
     }

--- a/RoktDemo/UI/Placement Demo/Summary/DemoItemSummaryViewModel.swift
+++ b/RoktDemo/UI/Placement Demo/Summary/DemoItemSummaryViewModel.swift
@@ -46,6 +46,9 @@ class DemoItemSummaryViewModel: ObservableObject {
         if model as? DefaultPlacementExamplesModel != nil {
             return AlertView.template2
         }
+        if model is ShoppableAdsModel {
+            return AlertView.shoppableAdsTemplate
+        }
         return AlertView.template1
     }
     


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- The Rokt SDK 5.0.0 introduced Shoppable Ads, a new feature that enables product browsing and purchasing within overlay placements using Stripe payments.
- The demo app currently has no way to test or demonstrate this feature. Operations and Go-to-Market teams need an easy way to configure and preview Shoppable Ads placements.

## What Has Changed

- Added a new "Shoppable Ads" item to the placement library (hardcoded in iOS — no backend changes needed since the server config is shared with Android)
- Added a 3-screen custom placement builder flow:
  - **Account Setup (Step 1/2):** Tag ID, Stripe Publishable Key, View Name — SDK init and Stripe payment extension registration happen here
  - **Attributes (Step 2/2):** Pre-populated default fields (email, name, address, etc.) with dynamic add/remove for additional key-value attributes
  - **Execution:** Calls `Rokt.selectShoppableAds()` and displays SDK event log (PlacementReady, CartItemInstantPurchase, etc.)
- Added `RoktStripePaymentExtension` SPM dependency
- Added Shoppable Ads-specific disclaimer (replaces generic "Yes please / No thanks" text)
- Updated README: removed stale sections, added Shoppable Ads to features, added new dependency
- Added CHANGELOG following Keep a Changelog format

## Screenshots/Video

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-13 at 11 05 57" src="https://github.com/user-attachments/assets/9611eb40-0c80-455f-9382-4455395ca4cc" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-13 at 11 06 04" src="https://github.com/user-attachments/assets/e846702e-bc91-4d71-a35a-818f828c3837" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-13 at 11 11 34" src="https://github.com/user-attachments/assets/10dfb38f-e30a-47f8-a28d-d27e4b832c19" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-13 at 11 11 53" src="https://github.com/user-attachments/assets/bf5aac51-5f12-4014-9b29-9ebbdcd42fda" />


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Apple Pay merchant ID is hardcoded to `merchant.rokt.demoapp` from the app entitlements — not configurable in the UI
- Default test attributes are pre-populated for quick testing (sandbox mode, sample shipping address, etc.)
- The `colormode` attribute is omitted from defaults as the SDK adds it automatically
- Build verified on iPhone 16 simulator with Xcode

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A