### PR TITLE
ci: build Firebase IPA with Xcode 26.2

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -5,7 +5,7 @@ inputs:
   xcode-version:
     description: "Version of Xcode to install"
     required: false
-    default: "16.4"
+    default: "26.2"
 
 runs:
   using: composite

--- a/.github/workflows/distribute-to-firebase.yml
+++ b/.github/workflows/distribute-to-firebase.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build-ipa:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,7 +24,7 @@ jobs:
           provisioning_profile_base64: ${{ secrets.MPARTICLE_ENTERPRISE_PROVISIONING_PROFILE_BASE64 }}
 
   publish-build-to-firebase:
-    runs-on: macos-15
+    runs-on: macos-latest
     needs: build-ipa
 
     steps:

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-ipa:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,7 +32,7 @@ jobs:
           provisioning_profile_base64: ${{ secrets.MPARTICLE_ENTERPRISE_PROVISIONING_PROFILE_BASE64 }}
 
   release-to-firebase-and-tag:
-    runs-on: macos-15
+    runs-on: macos-latest
     needs: build-ipa
 
     steps:

--- a/.github/workflows/trigger-release-to-firebase.yml
+++ b/.github/workflows/trigger-release-to-firebase.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   update-version:
-    runs-on: macos-15
+    runs-on: macos-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Background

- Firebase-distributed builds were being compiled with Xcode 16.4 (iOS 18.5 SDK), while local builds use Xcode 26.2 (iOS 26 SDK). On iOS 26 devices this produced different bottom-sheet rendering for the same app version because UIKit's sheet presentation is gated by `LC_BUILD_VERSION.sdk` (linked-on-or-after behavior).

## What Has Changed

- Default `xcode-version` in `./.github/actions/setup-xcode` bumped from `16.4` to `26.2`.
- Firebase-producing workflows (`distribute-to-firebase.yml`, `release-from-main.yml`, `trigger-release-to-firebase.yml`) now run on `macos-latest` (currently `macos-15-arm64`, which has Xcode 26.2 preinstalled).

## Screenshots/Video

- N/A (CI config change)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Future risk: when GitHub flips the `macos-latest` alias to `macos-26` (ETA 1-2 months), the `26.2` pin will fail the `setup-xcode` step (macos-26 only ships 26.4 / 26.5 beta). The failure will be loud, not silent, so we can re-pin at that time.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A

Made with [Cursor](https://cursor.com)