### PR TITLE
fix: enable Swift optimization in Debug to prevent stack overflow

### DIFF
--- a/RoktDemo.xcodeproj/project.pbxproj
+++ b/RoktDemo.xcodeproj/project.pbxproj
@@ -1148,7 +1148,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Debug;
 		};


### PR DESCRIPTION
## Background

- Running the demo app locally in Debug mode crashes with `EXC_BAD_ACCESS` (stack overflow) when decoding deeply nested layout JSON. This is caused by unoptimized (`-Onone`) stack frames being 2-4x larger than release builds, exceeding the decoding thread's stack limit.

## What Has Changed

- Changed `SWIFT_OPTIMIZATION_LEVEL` from `"-Onone"` to `"-O"` in the project-level Debug build configuration.

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- SwiftUI Previews are disabled when optimization is `-O`. Breakpoints still work but stepping through optimized code may skip lines. This is a reasonable trade-off for a demo app.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A

Made with [Cursor](https://cursor.com)