### PR TITLE
feat: add manual layout entry for previewable configs

### DIFF
--- a/RoktDemo.xcodeproj/project.pbxproj
+++ b/RoktDemo.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		2574716C261EB5C300B8C0C7 /* NavigationBarTransparent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2574716B261EB5C300B8C0C7 /* NavigationBarTransparent.swift */; };
 		25747171261EB5D200B8C0C7 /* NavigationBarBlack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25747170261EB5D200B8C0C7 /* NavigationBarBlack.swift */; };
 		25747A032A70D909009C5B69 /* LayoutDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25747A022A70D909009C5B69 /* LayoutDemoView.swift */; };
+		7EAD60812DCA5470009EC6DB /* ManualEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD60802DCA5470009EC6DB /* ManualEntryView.swift */; };
 		25747A062A70DBD5009C5B69 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 25747A052A70DBD5009C5B69 /* CodeScanner */; };
 		25747A092A721EEA009C5B69 /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25747A082A721EEA009C5B69 /* PreviewData.swift */; };
 		25747A0B2A723AD9009C5B69 /* LayoutDemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25747A0A2A723AD9009C5B69 /* LayoutDemoViewModel.swift */; };
@@ -217,6 +218,7 @@
 		2574716B261EB5C300B8C0C7 /* NavigationBarTransparent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarTransparent.swift; sourceTree = "<group>"; };
 		25747170261EB5D200B8C0C7 /* NavigationBarBlack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarBlack.swift; sourceTree = "<group>"; };
 		25747A022A70D909009C5B69 /* LayoutDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutDemoView.swift; sourceTree = "<group>"; };
+		7EAD60802DCA5470009EC6DB /* ManualEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualEntryView.swift; sourceTree = "<group>"; };
 		25747A082A721EEA009C5B69 /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
 		25747A0A2A723AD9009C5B69 /* LayoutDemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutDemoViewModel.swift; sourceTree = "<group>"; };
 		25747A0C2A723EDF009C5B69 /* LayoutDemoUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutDemoUIState.swift; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 			children = (
 				7EAD606D2DCA5470009EC6DB /* LayoutDemoUIView.swift */,
 				25747A022A70D909009C5B69 /* LayoutDemoView.swift */,
+				7EAD60802DCA5470009EC6DB /* ManualEntryView.swift */,
 				25747A0A2A723AD9009C5B69 /* LayoutDemoViewModel.swift */,
 			);
 			path = "Layout Demo";
@@ -922,6 +925,7 @@
 				2570F33C2627B38400B5B52E /* NavigationBarBlackWithButton.swift in Sources */,
 				251E3317274F297E00308A18 /* PreDefined3View.swift in Sources */,
 				25747A032A70D909009C5B69 /* LayoutDemoView.swift in Sources */,
+				7EAD60812DCA5470009EC6DB /* ManualEntryView.swift in Sources */,
 				256EB779261C206A00B959EF /* PreDefinedScreenModel.swift in Sources */,
 				7EAD606E2DCA5470009EC6DB /* LayoutDemoUIView.swift in Sources */,
 				25A0266626A51B860005CFED /* ErrorViewModel.swift in Sources */,

--- a/RoktDemo/Model/Layouts/PreviewData.swift
+++ b/RoktDemo/Model/Layouts/PreviewData.swift
@@ -13,11 +13,12 @@
 
 import Foundation
 
-struct PreviewData: Decodable {
+struct PreviewData: Codable {
     let tagId: String
     let previewId: String
     let versionId: String
     let creativeIds: [String]
     let layoutVariantIds: [String]
     let language: String
+    let catalogItemId: String?
 }

--- a/RoktDemo/UI/Home/HomePageView.swift
+++ b/RoktDemo/UI/Home/HomePageView.swift
@@ -58,7 +58,7 @@ struct HomePageView: View {
                         .navigationBarTitle(Text(""))
                         
                         NavigationLink(
-                            destination: LayoutDemoView(viewModel: LayoutDemoViewModel()),
+                            destination: LayoutDemoView(),
                             label: {
                                 Text("Layout library in SwiftUI")
                             })

--- a/RoktDemo/UI/Layout Demo/LayoutDemoView.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoView.swift
@@ -16,12 +16,13 @@ import CodeScanner
 import Rokt_Widget
 
 struct LayoutDemoView: View {
-    @ObservedObject var viewModel: LayoutDemoViewModel
+    @StateObject var viewModel: LayoutDemoViewModel = LayoutDemoViewModel()
     @EnvironmentObject var appState: AppState
     
     var roktEmbedded = RoktEmbeddedSwiftUIView()
     
     @State var isShowingBarcodeScanner = false
+    @State private var isShowingManualEntry = false
 
     @State private var embeddedSize: CGFloat = 0
     var body: some View {
@@ -41,15 +42,18 @@ struct LayoutDemoView: View {
                         .sheet(isPresented: $isShowingBarcodeScanner) {
                             CodeScannerView(codeTypes: [.qr], completion: handleScan)
                         }
-                        .onChange(of: viewModel.uiState){ newState in
-                            if newState == .hasData {
-                                showPlacement()
-                            }
-                            if newState == .loading {
-                                appState.previewParameterString = nil
-                            }
+
+                        Button(action: {
+                            isShowingManualEntry = true
+                        }) {
+                            Text("Enter Manually")
                         }
-                        
+                        .padding(.top, 8)
+                        .buttonStyle(ButtonDefaultOutlined())
+                        .sheet(isPresented: $isShowingManualEntry) {
+                            ManualEntryView(viewModel: viewModel, isPresented: $isShowingManualEntry)
+                        }
+
                         switch viewModel.uiState {
                         case .hasData, .done:
                             // TODO: Re-enable the refresh button once layoutVariantIds are stablised
@@ -81,6 +85,15 @@ struct LayoutDemoView: View {
                         viewModel.parseQRcodeResult(previewJsonString)
                     }
                 }
+                .onChange(of: viewModel.uiState){ newState in
+                    print("[LayoutDemoView] uiState changed → \(newState)")
+                    if newState == .hasData {
+                        showPlacement()
+                    }
+                    if newState == .loading {
+                        appState.previewParameterString = nil
+                    }
+                }
             } else {
                 VStack {
                     HeaderView(title: "Layout Library")
@@ -102,11 +115,14 @@ struct LayoutDemoView: View {
         }
     }
     func showPlacement() {
+        let attrs = viewModel.getAttributes()
+        print("[LayoutDemoView] showPlacement called. attributes=\(attrs)")
         Rokt.selectPlacements(
             identifier: "",
-            attributes: viewModel.getAttributes(),
+            attributes: attrs,
             placements: ["#rokt-placeholder": roktEmbedded.embedded]
         ) { event in
+            print("[LayoutDemoView] Rokt event: \(event)")
             switch event {
             case let sizeChanged as RoktEvent.EmbeddedSizeChanged:
                 embeddedSize = sizeChanged.updatedHeight
@@ -127,6 +143,6 @@ struct LayoutDemoView: View {
 
 struct LayoutDemoView_Previews: PreviewProvider {
     static var previews: some View {
-        LayoutDemoView(viewModel: LayoutDemoViewModel())
+        LayoutDemoView()
     }
 }

--- a/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
@@ -16,47 +16,70 @@ import Combine
 import Rokt_Widget
 
 class LayoutDemoViewModel: ObservableObject {
-    
+
     @Published var uiState = LayoutDemoUIState.initiated
     var preview: PreviewData? = nil
-    
+
     public var cancellable: AnyCancellable?
-    
+
     func parseQRcodeResult(_ result: String) {
+        print("[ViewModel] parseQRcodeResult input bytes=\(result.utf8.count)")
         let decoder = JSONDecoder()
         do {
-            guard let data = result.data(using: .utf8, allowLossyConversion: false) else { return }
+            guard let data = result.data(using: .utf8, allowLossyConversion: false) else {
+                print("[ViewModel] parseQRcodeResult: failed to get UTF-8 data")
+                return
+            }
             let preview = try decoder.decode(PreviewData.self, from: data)
+            print("[ViewModel] parseQRcodeResult: decoded OK, tagId=\(preview.tagId)")
             renderResult(preview: preview)
         } catch {
+            print("[ViewModel] parseQRcodeResult: decode FAILED \(error)")
             self.uiState = .error(error: error.localizedDescription)
         }
     }
-    
+
     private func renderResult(preview: PreviewData) {
+        print("[ViewModel] renderResult: spawning Task")
         Task {
+            print("[ViewModel] Task: entered. tagId.isEmpty=\(preview.tagId.isEmpty)")
             if !preview.tagId.isEmpty {
                 Rokt.initWith(roktTagId: preview.tagId)
             }
-            try await Task.sleep(seconds: 3)
-            
+            print("[ViewModel] Task: initWith returned, starting 3s sleep")
+            do {
+                try await Task.sleep(seconds: 3)
+            } catch {
+                print("[ViewModel] Task: sleep threw \(error) (likely cancelled). isCancelled=\(Task.isCancelled)")
+                return
+            }
+            print("[ViewModel] Task: sleep finished, about to set uiState=.hasData")
+
             self.preview = preview
             await MainActor.run{
                 uiState = .hasData
+                print("[ViewModel] Task: uiState set to .hasData on MainActor")
             }
-           
         }
     }
-    
+
     func getAttributes() -> [String: String] {
         guard let preview else { return [:] }
         var attributes = [String: String]()
         attributes["isDemo"] = "true"
-        attributes["rokt.language"] = preview.language
-        
+        attributes["upsellsProviderName"] = "canal"
+        attributes["firstname"] = "ops"
+        attributes["lastname"] = "test"
+        attributes["email"] = "jenny.smith@example.com"
+        attributes["confirmationref"] = "ORD-12345"
+        attributes["billingzipcode"] = "07762"
+        if let catalogItemId = preview.catalogItemId, !catalogItemId.isEmpty {
+            attributes["catalogItemId"] = catalogItemId
+        }
+
         var slots: [[String: String]] = []
         let layoutVariantCount = preview.layoutVariantIds.count
-        
+
         for (index, creativeId) in preview.creativeIds.enumerated() {
             let layoutVariantId = preview.layoutVariantIds[index % layoutVariantCount]
             let slot: [String: String] = [
@@ -65,22 +88,21 @@ class LayoutDemoViewModel: ObservableObject {
             ]
             slots.append(slot)
         }
-        
+
         let demoConfig = [
             "layouts": [
                 [
                     "layoutId": preview.previewId,
-                    "versionId": preview.versionId,
                     "slots": slots
                 ]
             ]
         ]
-        
+
         if let demoConfigJson = try? JSONSerialization.data(withJSONObject: demoConfig, options: []),
            let demoConfigJsonString = String(data: demoConfigJson, encoding: .utf8) {
             attributes["demoConfig"] = demoConfigJsonString
         }
-        
+
         return attributes
     }
 }

--- a/RoktDemo/UI/Layout Demo/ManualEntryView.swift
+++ b/RoktDemo/UI/Layout Demo/ManualEntryView.swift
@@ -1,0 +1,109 @@
+//
+//  ManualEntryView.swift
+//  RoktDemo
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import SwiftUI
+
+struct ManualEntryView: View {
+    @ObservedObject var viewModel: LayoutDemoViewModel
+    @Binding var isPresented: Bool
+
+    @AppStorage("manualEntry.tagId") private var tagId: String = "2992045596330978209"
+    @AppStorage("manualEntry.previewId") private var previewId: String = "3570823419066187777"
+    @AppStorage("manualEntry.versionId") private var versionId: String = "1779204183552"
+    @AppStorage("manualEntry.creativeIdsText") private var creativeIdsText: String = "3490020616040873984"
+    @AppStorage("manualEntry.layoutVariantIdsText") private var layoutVariantIdsText: String = "3588707418073595917"
+    @AppStorage("manualEntry.language") private var language: String = "en"
+    @AppStorage("manualEntry.catalogItemId") private var catalogItemId: String = "02b4225b-f1b2-470f-8fe6-0fcf980e500c"
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Manual Layout Entry")
+                        .font(.defaultBoldFont(.header2))
+                        .foregroundColor(.titleColor)
+
+                    Text("Enter the same fields a QR code would carry. Comma-separate IDs that take arrays.")
+                        .font(.defaultFont(.subtitle1))
+                        .foregroundColor(.subtitleColor)
+
+                    DetailTextFieldView(title: "Tag ID", textHolder: $tagId)
+                    DetailTextFieldView(title: "Layout ID", textHolder: $previewId)
+                    DetailTextFieldView(title: "Version ID", textHolder: $versionId)
+                    DetailTextFieldView(title: "Creative IDs (comma-separated)", textHolder: $creativeIdsText)
+                    DetailTextFieldView(title: "Layout Variant IDs (comma-separated)", textHolder: $layoutVariantIdsText)
+                    DetailTextFieldView(title: "Language", textHolder: $language)
+                    DetailTextFieldView(title: "Catalog Item ID (optional)", textHolder: $catalogItemId)
+
+                    Button(action: render) {
+                        Text("Render Layout")
+                    }
+                    .buttonStyle(ButtonDefault())
+                    .padding(.top, 8)
+                    .disabled(!canRender)
+
+                    Button(action: { isPresented = false }) {
+                        Text("Cancel")
+                    }
+                    .buttonStyle(ButtonDefaultOutlined())
+                }
+                .padding()
+            }
+            .background(Color.gray3)
+            .modifier(NavigationBarGray(title: ""))
+        }
+    }
+
+    private var canRender: Bool {
+        !tagId.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !previewId.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !versionId.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !splitCSV(creativeIdsText).isEmpty &&
+            !splitCSV(layoutVariantIdsText).isEmpty &&
+            !language.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private func buildPreview() -> PreviewData {
+        let trimmedCatalogId = catalogItemId.trimmingCharacters(in: .whitespaces)
+        return PreviewData(
+            tagId: tagId.trimmingCharacters(in: .whitespaces),
+            previewId: previewId.trimmingCharacters(in: .whitespaces),
+            versionId: versionId.trimmingCharacters(in: .whitespaces),
+            creativeIds: splitCSV(creativeIdsText),
+            layoutVariantIds: splitCSV(layoutVariantIdsText),
+            language: language.trimmingCharacters(in: .whitespaces),
+            catalogItemId: trimmedCatalogId.isEmpty ? nil : trimmedCatalogId
+        )
+    }
+
+    private func render() {
+        let preview = buildPreview()
+
+        guard
+            let data = try? JSONEncoder().encode(preview),
+            let json = String(data: data, encoding: .utf8)
+        else {
+            viewModel.uiState = .error(error: "Failed to encode manual entry payload")
+            return
+        }
+
+        isPresented = false
+        viewModel.uiState = .loading
+        viewModel.parseQRcodeResult(json)
+    }
+
+    private func splitCSV(_ text: String) -> [String] {
+        text.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+}

--- a/RoktDemo/UI/Layout Demo/ManualEntryView.swift
+++ b/RoktDemo/UI/Layout Demo/ManualEntryView.swift
@@ -15,7 +15,7 @@ struct ManualEntryView: View {
     @ObservedObject var viewModel: LayoutDemoViewModel
     @Binding var isPresented: Bool
 
-    @AppStorage("manualEntry.tagId") private var tagId: String = "2992045596330978209"
+    @AppStorage("manualEntry.tagId") private var tagId: String = "343"
     @AppStorage("manualEntry.previewId") private var previewId: String = "3570823419066187777"
     @AppStorage("manualEntry.versionId") private var versionId: String = "1779204183552"
     @AppStorage("manualEntry.creativeIdsText") private var creativeIdsText: String = "3490020616040873984"


### PR DESCRIPTION
## Background

- The SwiftUI Layout Demo previously required scanning a QR code to load a preview layout config. This PR adds a manual-entry path so the same fields the OP generated QR code carries can be typed in by hand, including an optional catalog item ID used for shoppable-ad previews.

## What Has Changed

- **New `ManualEntryView`** — a sheet with fields for tag ID, preview ID, version ID, creative IDs, variant, and an optional catalog item ID. Values are persisted via `@AppStorage` with defaults for a known-working combination.
- **`PreviewData`** — now `Codable` and gains an optional `catalogItemId` property.
- **`LayoutDemoView`** — adds an "Enter Manually" button and presents the sheet; owns the view model via `@StateObject` so the render `Task` survives parent re-renders; moves `.onChange` to screen level so `showPlacement` fires reliably.
- **`LayoutDemoViewModel.getAttributes`** — passes `catalogItemId` along with the demo attributes.
- **`HomePageView`** — minor wiring update for the above.
- **Xcode project** — registers `ManualEntryView.swift`.

## Video

https://github.com/user-attachments/assets/ca19c7f2-c7ee-4285-b4f0-a0720aef6c1b


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- No automated tests were added with these changes.
