### PR TITLE
feat(layout-demo): migrate demo mode to new api demo_config dialect (SDK 5.3.1)

### DIFF
--- a/RoktDemo.xcodeproj/project.pbxproj
+++ b/RoktDemo.xcodeproj/project.pbxproj
@@ -1422,7 +1422,7 @@
 			repositoryURL = "https://github.com/ROKT/rokt-sdk-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.5;
+				minimumVersion = 5.3.1;
 			};
 		};
 		3B0A1C2D3E4F5A6B7C8D9E2E /* XCRemoteSwiftPackageReference "rokt-payment-extension-ios" */ = {

--- a/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
@@ -68,6 +68,11 @@ class LayoutDemoViewModel: ObservableObject {
         var attributes = [String: String]()
         // Demo signal for the demo_config layout-preview path.
         attributes["isDemo"] = "true"
+        // Required: layouts carrying LANG placeholders are excluded from the
+        // render when no language attribute is present (verified on prod —
+        // omitting it returns a 200 with zero plugins). PreviewData has
+        // carried this value all along.
+        attributes["language"] = preview.language
         attributes["firstname"] = "ops"
         attributes["lastname"] = "test"
         attributes["email"] = "jenny.smith@example.com"

--- a/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
+++ b/RoktDemo/UI/Layout Demo/LayoutDemoViewModel.swift
@@ -66,33 +66,56 @@ class LayoutDemoViewModel: ObservableObject {
     func getAttributes() -> [String: String] {
         guard let preview else { return [:] }
         var attributes = [String: String]()
+        // Demo signal for the demo_config layout-preview path.
         attributes["isDemo"] = "true"
-        attributes["upsellsProviderName"] = "canal"
         attributes["firstname"] = "ops"
         attributes["lastname"] = "test"
         attributes["email"] = "jenny.smith@example.com"
         attributes["confirmationref"] = "ORD-12345"
         attributes["billingzipcode"] = "07762"
-        if let catalogItemId = preview.catalogItemId, !catalogItemId.isEmpty {
-            attributes["catalogItemId"] = catalogItemId
-        }
 
-        var slots: [[String: String]] = []
+        // On the demo path, catalog creatives render from items supplied inline
+        // on the slot. The preview payload carries item-group ids only, so
+        // synthesize deterministic placeholder items for a stable preview.
+        let catalogItems: [[String: Any]] = (preview.catalogItemId ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .enumerated()
+            .map { index, itemId in
+                [
+                    "item_id": itemId,
+                    "price": 19.99,
+                    "original_price": 24.99,
+                    "currency": "USD",
+                    "copy": ["title": "Demo item \(index + 1)"],
+                    "group_id": itemId
+                ]
+            }
+
+        var slots: [[String: Any]] = []
         let layoutVariantCount = preview.layoutVariantIds.count
 
         for (index, creativeId) in preview.creativeIds.enumerated() {
             let layoutVariantId = preview.layoutVariantIds[index % layoutVariantCount]
-            let slot: [String: String] = [
-                "layoutVariantId": layoutVariantId,
-                "creativeId": creativeId
+            var slot: [String: Any] = [
+                "layout_variant_id": layoutVariantId,
+                "creative_id": creativeId
             ]
+            if !catalogItems.isEmpty {
+                slot["catalog_items"] = catalogItems
+            }
             slots.append(slot)
         }
 
-        let demoConfig = [
+        // demo_config payload: the attribute key and its fields are snake_case
+        // (the camelCase form is rejected), and version_id is required so the
+        // saved draft the QR code points at can be resolved.
+        let demoConfig: [String: Any] = [
             "layouts": [
                 [
-                    "layoutId": preview.previewId,
+                    "layout_id": preview.previewId,
+                    "version_id": preview.versionId,
                     "slots": slots
                 ]
             ]
@@ -100,7 +123,7 @@ class LayoutDemoViewModel: ObservableObject {
 
         if let demoConfigJson = try? JSONSerialization.data(withJSONObject: demoConfig, options: []),
            let demoConfigJsonString = String(data: demoConfigJson, encoding: .utf8) {
-            attributes["demoConfig"] = demoConfigJsonString
+            attributes["demo_config"] = demoConfigJsonString
         }
 
         return attributes


### PR DESCRIPTION
## Why

The Layout Demo screen still drives the legacy preview path for demo mode. That path is being retired, so this moves the screen onto the current `/v2/sessions/offers` API that the SDK already uses from 5.3.0 onward.

## What

Two changes, both scoped to the Layout Demo (QR / manual entry) flow:

1. **`rokt-sdk-ios` 5.2.5 → 5.3.1.** The new API architecture (init/offers/events) landed in the SDK in 5.3.0 (#255), routing `selectPlacements` to `/v2/sessions/offers`.
2. **`LayoutDemoViewModel.getAttributes()` emits the current demo payload:**
   - `demo_config` (snake_case) — the camelCase `demoConfig` key is rejected;
   - **`version_id` now included** — required so the saved draft the QR code points at can be resolved. The value was already carried in `PreviewData` / manual entry but silently dropped by the old code;
   - **inline `catalog_items`** synthesized from the `catalogItemId` group ids — catalog creatives now render from items supplied on the slot. Deterministic placeholder content (title/price) replaces live provider data: for layout preview, stable render data is the point;
   - dropped `upsellsProviderName` and the bare `catalogItemId` attribute — they only steered the old path and do nothing now.

## Validation notes for reviewers

- Suggested app-level check: save a draft layout in the editor → QR scan with this build → confirm render; then a catalog-creative draft → confirm items render with the placeholder content.
- `isDemo=true` is correct on this path — demo requests do not produce billable events.
- Not touched: the Shoppable Ads screen (separate flow, out of scope) and all other demo screens.

## Rollback

Revert this PR — the old path remains functional for now.

## Deliberately dropped capability (not an oversight)

The old flow's "real provider items appear automatically" behaviour depended on the path being retired. This PR replaces it with deterministic inline items, which is the right trade for draft-preview work — stable render data is a feature for layout review, not a compromise. Flagging it here so the capability change is a reviewed decision rather than an accident. If mobile demos genuinely need live provider items, that should be scoped as a separate follow-up; it would need UI/input changes only, not SDK work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
