### PR TITLE
fix: unblock enterprise IPA build and make signing failures visible

### DIFF
--- a/.github/actions/build-ipa/action.yml
+++ b/.github/actions/build-ipa/action.yml
@@ -15,6 +15,13 @@ inputs:
     description: Path to ExportOptions.plist
     required: false
     default: ExportOptions.plist
+  entitlements_plist:
+    description: >
+      Entitlements to archive with, checked against the provisioning profile. Defaults to
+      the enterprise variant, which omits the Apple Pay entitlement the mParticle team
+      cannot provision. See RoktDemoEnterprise.entitlements for why.
+    required: false
+    default: RoktDemo/RoktDemoEnterprise.entitlements
 
 runs:
   using: composite
@@ -31,12 +38,51 @@ runs:
         echo "${{ inputs.certificate_p12_base64 }}" | base64 --decode > certificate.p12
         security import certificate.p12 -k build.keychain -P "${{ inputs.certificate_password }}" -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+        # The key now lives in the keychain; don't leave it lying in the checkout.
+        rm -f certificate.p12
 
     - name: Install provisioning profile
       shell: bash
       run: |
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
         echo "${{ inputs.provisioning_profile_base64 }}" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
+
+    - name: Verify signing assets
+      shell: bash
+      run: |
+        PROFILE="$HOME/Library/MobileDevice/Provisioning Profiles/profile.mobileprovision"
+        security find-identity -v -p codesigning build.keychain
+
+        # find-identity only lists unexpired, usable identities, so a count of 0 means
+        # the distribution certificate is missing or expired.
+        if security find-identity -v -p codesigning build.keychain | grep -q "^ *0 valid identities found"; then
+          echo "::error::No valid codesigning identity in the keychain. The distribution certificate is missing or expired."
+          exit 1
+        fi
+
+        security cms -D -i "$PROFILE" > "$RUNNER_TEMP/profile.plist"
+        NAME=$(plutil -extract Name raw "$RUNNER_TEMP/profile.plist")
+        EXPIRY=$(plutil -extract ExpirationDate raw "$RUNNER_TEMP/profile.plist")
+        echo "Provisioning profile '$NAME' expires $EXPIRY"
+
+        if [ "$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$EXPIRY" +%s)" -lt "$(date +%s)" ]; then
+          echo "::error::Provisioning profile '$NAME' expired on $EXPIRY. Regenerate it in the Apple Developer portal and update the repository secret."
+          exit 1
+        fi
+
+        # The profile must grant every entitlement the app declares, or codesigning fails.
+        # Match on the raw XML rather than `plutil -extract`, which reads the dots in
+        # reverse-DNS entitlement keys as keypath separators and never finds them.
+        plutil -extract Entitlements xml1 -o "$RUNNER_TEMP/profile-entitlements.plist" "$RUNNER_TEMP/profile.plist"
+        MISSING=""
+        while read -r KEY; do
+          grep -qF "<key>$KEY</key>" "$RUNNER_TEMP/profile-entitlements.plist" || MISSING="$MISSING $KEY"
+        done < <(plutil -convert xml1 -o - "${{ inputs.entitlements_plist }}" | grep -o '<key>[^<]*</key>' | sed 's/<\/*key>//g')
+
+        if [ -n "$MISSING" ]; then
+          echo "::error::Provisioning profile '$NAME' is missing entitlements required by ${{ inputs.entitlements_plist }}:$MISSING. Add the matching capabilities to the App ID and regenerate the profile."
+          exit 1
+        fi
 
     - name: Archive the app
       shell: bash
@@ -45,7 +91,8 @@ runs:
           -scheme RoktDemo \
           -configuration Release \
           -archivePath build/RoktDemo.xcarchive \
-          archive | xcpretty
+          CODE_SIGN_ENTITLEMENTS="${{ inputs.entitlements_plist }}" \
+          archive 2>&1 | tee "$RUNNER_TEMP/archive.log" | xcbeautify --renderer github-actions
 
     - name: Export the app
       shell: bash
@@ -53,7 +100,22 @@ runs:
         xcodebuild -exportArchive \
           -archivePath build/RoktDemo.xcarchive \
           -exportOptionsPlist ${{ inputs.export_options_plist }} \
-          -exportPath build | xcpretty
+          -exportPath build 2>&1 | tee "$RUNNER_TEMP/export.log" | xcbeautify --renderer github-actions
+
+    # Runs after both xcodebuild steps so it reports whichever one failed.
+    - name: Report xcodebuild errors
+      if: failure()
+      shell: bash
+      run: |
+        # Belt and braces: xcbeautify surfaces errors inline, but it is still a parser.
+        # This reports the raw logs so a diagnostic can never be lost to a formatter again.
+        # A log is absent when its step never ran, so skip those.
+        for LOG in "$RUNNER_TEMP/archive.log" "$RUNNER_TEMP/export.log"; do
+          [ -f "$LOG" ] || continue
+          echo "::group::$(basename "$LOG")"
+          grep -E "error:|^\*\* [A-Z]+ FAILED" "$LOG" || tail -n 50 "$LOG"
+          echo "::endgroup::"
+        done
 
     - name: Upload IPA artifact
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/RoktDemo/RoktDemoEnterprise.entitlements
+++ b/RoktDemo/RoktDemoEnterprise.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the mParticle Inc enterprise build (team 9RE44VD454, Universal
+  Distribution) produced by distribute-to-firebase.yml and release-from-main.yml.
+
+  Deliberately omits com.apple.developer.in-app-payments. Apple Pay requires an explicit
+  App ID, and Apple scopes both explicit App IDs and merchant IDs globally rather than
+  per team. `com.rokt.RoktDemo` and `merchant.rokt.demoapp` are registered to the Rokt
+  team (EX8W57PJ9C), so the mParticle team cannot claim either and its profile covers
+  only the wildcard `com.rokt.*`. Requesting the entitlement here fails codesigning with
+  "doesn't include the Apple Pay capability".
+
+  Apple Pay therefore works only in App Store / TestFlight builds, which sign under
+  EX8W57PJ9C via the fastlane `beta` lane and use RoktDemo.entitlements.
+-->
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
## Background

- The release and Firebase workflows have failed at `Archive the app` on every run since 2026-05-04 (last green: 2026-04-03), showing only `** ARCHIVE FAILED **` and exit 65.
- Two causes. **(1)** c063abc added an Apple Pay entitlement (`merchant.rokt.demoapp`). Apple Pay needs an *explicit* App ID, and Apple scopes App IDs and merchant IDs globally — both belong to the Rokt team (`EX8W57PJ9C`), so the mParticle enterprise team (`9RE44VD454`) can't provision them and only has the wildcard `com.rokt.*`. Not fixable in the portal. **(2)** The `Rokt demo apps` profile expired 2026-08-07.
- Nobody saw the reason because both xcodebuild steps piped through `xcpretty`, which can't parse Xcode 26 output — 0 lines emitted from 140 lines of stdout, all four errors lost.

## What Has Changed

- Archive the enterprise build with a new `RoktDemoEnterprise.entitlements` that omits Apple Pay. **App Store/TestFlight builds keep Apple Pay** — they sign under `EX8W57PJ9C` and still use `RoktDemo.entitlements`. `pbxproj`, `ExportOptions.plist` and fastlane are untouched.
- Replace `xcpretty` with `xcbeautify` (preinstalled on `macos-26-arm64`); keeps all errors and annotates them inline. Raw logs teed and reported on failure.
- Add a `Verify signing assets` preflight that fails with a named error on an invalid identity, an expired profile (naming the date), or a missing entitlement.
- Delete the decoded `.p12` from the checkout after import.
- Profile already regenerated out of band (now expires 2027-08-11) and the repo secret updated; the distribution cert is valid to 2028 and was not rotated.

## Screenshots/Video

- N/A — CI change.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified locally against the real signing assets: `ARCHIVE SUCCEEDED` → `EXPORT SUCCEEDED`, 7.1M IPA signed by `iPhone Distribution: mParticle Inc`, no Apple Pay entitlement in the binary. Archiving with `main`'s config and the *new* profile still fails, confirming this PR is required.
- No tests added — this is CI config; correctness was verified by running both the failure and success paths.
- **Follow-up:** `RoktPaymentExtension(applePayMerchantId:urlScheme:)` (`ShoppableAdsAccountView.swift:74`) is a failable init that also carries the Stripe/Afterpay flows. Whether card payments survive without the entitlement is untested — worth checking the first Firebase build before demoing. Apple Pay demos should use TestFlight.
- `MPARTICLE_ENTERPRISE_PROVISIONING_PROFILE` (no `_BASE64`) is unreferenced and can be deleted.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A — no ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
