### PR TITLE
fix: stop the build keychain auto-locking mid-archive

### DIFF
--- a/.github/actions/build-ipa/action.yml
+++ b/.github/actions/build-ipa/action.yml
@@ -34,6 +34,10 @@ runs:
       run: |
         security create-keychain -p "" build.keychain
         security default-keychain -s build.keychain
+        # A new keychain defaults to `lock-on-sleep timeout=300s`. This build takes longer
+        # than 300s, and codesign blocks indefinitely on a relocked keychain rather than
+        # failing, so disable auto-locking. Passing no -l/-u/-t yields `no-timeout`.
+        security set-keychain-settings build.keychain
         security unlock-keychain -p "" build.keychain
         echo "${{ inputs.certificate_p12_base64 }}" | base64 --decode > certificate.p12
         security import certificate.p12 -k build.keychain -P "${{ inputs.certificate_password }}" -T /usr/bin/codesign


### PR DESCRIPTION
## Background

- The IPA build stalls partway through `Archive the app` and never finishes; the job only ends when cancelled. Post-job cleanup reports an orphaned `codesign` process.
- `security create-keychain` leaves a new keychain set to `lock-on-sleep timeout=300s`. The archive now takes longer than that, so the keychain relocks mid-build and `codesign` blocks waiting for an authorisation that never arrives on a headless runner. It hangs rather than failing, so nothing is logged.
- Latent rather than new: the build previously failed early during signing and never reached `codesign`, and the last green build predates the payment dependencies that roughly doubled compile time.

## What Has Changed

- Disable auto-locking on the build keychain for the life of the job. `security set-keychain-settings` with no `-l`/`-u`/`-t` yields `no-timeout`.

## Screenshots/Video

- N/A — CI change.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Verified against a scratch keychain: after `create-keychain` the settings read `lock-on-sleep timeout=300s`; after `set-keychain-settings` they read `no-timeout`. The hang itself cannot be reproduced locally, so this needs a CI run to confirm end to end.
- Suggested follow-up: add `timeout-minutes` to the job so a future hang cannot run to the 6-hour default.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
